### PR TITLE
BeanManagerAware API changes

### DIFF
--- a/impl/src/main/java/org/jboss/seam/solder/beanManager/BeanManagerAccessor.java
+++ b/impl/src/main/java/org/jboss/seam/solder/beanManager/BeanManagerAccessor.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
  * 
  * @author Pete Muir
  * @author Nicklas Karlsson
+ * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * 
  */
 public class BeanManagerAccessor
@@ -42,14 +43,10 @@ public class BeanManagerAccessor
     * Obtain the {@link BeanManager} from the {@link BeanManagerProvider}s
     * 
     * @return the current bean manager for the bean archive
+    * @throws BeanManagerNotAvailable when the bean manager is not available
     */
-   public static BeanManager getBeanManager()
+   public static BeanManager getBeanManager() throws BeanManagerNotAvailable
    {
       return new BeanManagerAware().getBeanManager();
-   }
-
-   public static boolean isBeanManagerAvailable()
-   {
-      return new BeanManagerAware().isBeanManagerAvailable();
    }
 }

--- a/impl/src/main/java/org/jboss/seam/solder/beanManager/BeanManagerAware.java
+++ b/impl/src/main/java/org/jboss/seam/solder/beanManager/BeanManagerAware.java
@@ -53,6 +53,7 @@ import org.jboss.seam.solder.util.service.ServiceLoader;
  * 
  * @author Pete Muir
  * @author Nicklas Karlsson
+ * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
 public class BeanManagerAware
 {
@@ -81,8 +82,9 @@ public class BeanManagerAware
     * Obtain the {@link BeanManager} from the {@link BeanManagerProvider}s
     * 
     * @return the current bean manager for the bean archive
+    * @throws BeanManagerNotAvailable when the bean manager is not available
     */
-   protected BeanManager getBeanManager()
+   protected BeanManager getBeanManager() throws BeanManagerNotAvailable
    {
       if (beanManager == null)
       {
@@ -90,27 +92,9 @@ public class BeanManagerAware
       }
       if (beanManager == null)
       {
-         throw new IllegalStateException("Could not locate a BeanManager from the providers " + providersToString());
+         throw new BeanManagerNotAvailable("Could not locate a BeanManager from the providers " + providersToString());
       }
       return beanManager;
-   }
-
-   /**
-    * Check if {@link BeanManagerAware} has been able to find the bean manager
-    * 
-    * @return <code>true</code> if the bean manager has been found, otherwise
-    *         <code>false</code>
-    */
-   protected boolean isBeanManagerAvailable()
-   {
-      if (beanManager == null)
-      {
-         return lookupBeanManager() != null;
-      }
-      else
-      {
-         return true;
-      }
    }
 
    private String providersToString()

--- a/impl/src/main/java/org/jboss/seam/solder/beanManager/BeanManagerNotAvailable.java
+++ b/impl/src/main/java/org/jboss/seam/solder/beanManager/BeanManagerNotAvailable.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.seam.solder.beanManager;
+
+
+/**
+ * Thrown when the BeanManager is not accessible.
+ * 
+ * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * 
+ */
+public class BeanManagerNotAvailable extends Exception
+{
+   private static final long serialVersionUID = -6822877990144976878L;
+
+   public BeanManagerNotAvailable()
+   {
+   }
+
+   public BeanManagerNotAvailable(String message)
+   {
+      super(message);
+   }
+
+   public BeanManagerNotAvailable(Throwable e)
+   {
+      super(e);
+   }
+
+   public BeanManagerNotAvailable(String message, Throwable e)
+   {
+      super(message, e);
+   }
+
+}


### PR DESCRIPTION
This should really be a checked exception, since most of the time the fact that a BeanManager is not available is a failure case and should be recovered from. Certainly with regard to Seam and other CDI extensions. Returning null is as bad or worse than throwing IllegalStateException(), which is not a good experience when attempting to properly handle exceptions. BeanManagerNotAvailable is much more descriptive and selective. https://issues.jboss.org/browse/SOLDER-50
