### PR TITLE
Allow generic beans to be configured via qualifers

### DIFF
--- a/docs/src/main/docbook/en-US/genericbeans.xml
+++ b/docs/src/main/docbook/en-US/genericbeans.xml
@@ -177,13 +177,6 @@ class DurableQueueConfiguration extends MessageSystemConfiguration {
          <code>MessageSystemConfiguration</code>); the type produced by the generic configuration point must be of this 
          type. Additionally it defines the member <code>name</code>, used to provide the queue name. 
       </para>
-      
-      <important>
-         <para>
-            All generic configuration annotations should have at least one member. Each configuration must specify a 
-            unique value for this member.
-         </para>
-      </important>
 
       <para>
          Next, we define the queue manager bean. The manager has one producer method, which creates the queue from the

--- a/impl/src/main/java/org/jboss/seam/solder/bean/generic/AbstactGenericBean.java
+++ b/impl/src/main/java/org/jboss/seam/solder/bean/generic/AbstactGenericBean.java
@@ -43,7 +43,7 @@ abstract class AbstactGenericBean<T> extends ForwardingBean<T> implements Passiv
    private final boolean alternative;
    private final Class<?> beanClass;
 
-   protected AbstactGenericBean(Bean<T> delegate, Set<Annotation> qualifiers, Annotation configuration, String id, boolean alternative, Class<?> beanClass, BeanManager beanManager)
+   protected AbstactGenericBean(Bean<T> delegate, Set<Annotation> qualifiers, GenericIdentifier identifier, String id, boolean alternative, Class<?> beanClass, BeanManager beanManager)
    {
       this.delegate = delegate;
       this.beanManager = beanManager;
@@ -58,7 +58,7 @@ abstract class AbstactGenericBean<T> extends ForwardingBean<T> implements Passiv
          }
       }
       this.qualifiers.add(AnyLiteral.INSTANCE);
-      this.id = getClass().getName() + "-" + configuration.toString() + "-" + id;
+      this.id = getClass().getName() + "-" + identifier.toString() + "-" + id;
       this.alternative = alternative;
       this.beanClass = beanClass;
    }

--- a/impl/src/main/java/org/jboss/seam/solder/bean/generic/AbstractGenericProducerBean.java
+++ b/impl/src/main/java/org/jboss/seam/solder/bean/generic/AbstractGenericProducerBean.java
@@ -41,9 +41,9 @@ abstract class AbstractGenericProducerBean<T> extends AbstactGenericBean<T>
    private final Annotation[] declaringBeanQualifiers;
    private final Class<? extends Annotation> scopeOverride;
 
-   protected AbstractGenericProducerBean(Bean<T> delegate, Annotation genericConfiguration, Set<Annotation> qualifiers, Set<Annotation> declaringBeanQualifiers, Class<? extends Annotation> scopeOverride, String id, boolean alternative, Class<?> beanClass, BeanManager beanManager)
+   protected AbstractGenericProducerBean(Bean<T> delegate, GenericIdentifier identifier, Set<Annotation> qualifiers, Set<Annotation> declaringBeanQualifiers, Class<? extends Annotation> scopeOverride, String id, boolean alternative, Class<?> beanClass, BeanManager beanManager)
    {
-      super(delegate, qualifiers, genericConfiguration, id, alternative, beanClass, beanManager);
+      super(delegate, qualifiers, identifier, id, alternative, beanClass, beanManager);
       this.declaringBeanType = delegate.getBeanClass();
       this.declaringBeanQualifiers = declaringBeanQualifiers.toArray(Reflections.EMPTY_ANNOTATION_ARRAY);
       this.scopeOverride = scopeOverride;

--- a/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericBeanExtension.java
+++ b/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericBeanExtension.java
@@ -35,6 +35,7 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Disposes;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.AfterBeanDiscovery;
 import javax.enterprise.inject.spi.AfterDeploymentValidation;
@@ -329,6 +330,16 @@ public class GenericBeanExtension implements Extension
                ctx.getAnnotationBuilder().add(GenericMarkerLiteral.INSTANCE).add(genericBeanQualifier);
             }
             
+         });
+         builder.redefine(Disposes.class, new AnnotationRedefiner<Disposes>()
+         {
+
+            public void redefine(RedefinitionContext<Disposes> ctx)
+            {
+               // Add the marker qualifier
+               ctx.getAnnotationBuilder().add(GenericMarkerLiteral.INSTANCE).add(genericBeanQualifier);
+            }
+
          });
 
          builder.redefine(Generic.class, new AnnotationRedefiner<Generic>()

--- a/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericBeanExtension.java
+++ b/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericBeanExtension.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.Map.Entry;
@@ -246,7 +247,7 @@ public class GenericBeanExtension implements Extension
 
    // A map of a generic configuration types to generic configurations
    // Used to track the generic configuration producers found
-   private final Map<Annotation, GenericConfigurationHolder> genericConfigurationPoints;
+   private final Map<GenericIdentifier, GenericConfigurationHolder> genericConfigurationPoints;
 
    // A map of a generic configuration types to generic configurations
    // Used to track the generic configuration producers found
@@ -274,7 +275,7 @@ public class GenericBeanExtension implements Extension
       this.genericBeanObserverMethods = Multimaps.newSetMultimap(new HashMap<Class<? extends Annotation>, Collection<ObserverMethodHolder<?, ?>>>(), GenericBeanExtension.<ObserverMethodHolder<?, ?>> createHashSetSupplier());
       this.genericBeanProducerFields = Multimaps.newSetMultimap(new HashMap<Class<? extends Annotation>, Collection<FieldHolder<?, ?>>>(), GenericBeanExtension.<FieldHolder<?, ?>> createHashSetSupplier());
       this.genericInjectionTargets = new HashMap<AnnotatedType<?>, InjectionTarget<?>>();
-      this.genericConfigurationPoints = new HashMap<Annotation, GenericConfigurationHolder>();
+      this.genericConfigurationPoints = new HashMap<GenericIdentifier, GenericConfigurationHolder>();
       this.genericProducerBeans = new HashMap<AnnotatedMember<?>, Bean<?>>();
       this.unwrapsMethods = Multimaps.newSetMultimap(new HashMap<Class<? extends Annotation>, Collection<AnnotatedMethod<?>>>(), GenericBeanExtension.<AnnotatedMethod<?>> createHashSetSupplier());
       this.genericBeanQualifier = new Synthetic.SyntheticLiteral("org.jboss.seam.solder.bean.generic.genericQualifier", Long.valueOf(0));
@@ -476,7 +477,18 @@ public class GenericBeanExtension implements Extension
                throw new IllegalStateException("Generic configuration " + genericConfiguration + " is defined twice [" + event.getAnnotated() + ", " + genericConfigurationPoints.get(genericConfiguration).getAnnotated() + "]");
             }
             // Register the bean for use later
-            genericConfigurationPoints.put(genericConfiguration, new GenericConfigurationHolder(event.getAnnotated(), event.getBean().getBeanClass()));
+            Set<Annotation> qualifiers = event.getBean().getQualifiers();
+            Iterator<Annotation> iterator = qualifiers.iterator();
+            while (iterator.hasNext())
+            {
+               Annotation qualifier = iterator.next();
+               if (qualifier.annotationType().equals(Synthetic.class))
+               {
+                  iterator.remove();
+               }
+            }
+            GenericIdentifier identifier = new GenericIdentifier(qualifiers, genericConfiguration);
+            genericConfigurationPoints.put(identifier, new GenericConfigurationHolder(event.getAnnotated(), event.getBean().getBeanClass()));
          }
       }
    }
@@ -485,7 +497,7 @@ public class GenericBeanExtension implements Extension
    {
       beanDiscoveryOver = true;
       // For each generic configuration type, we iterate the generic configurations
-      for (Entry<Annotation, GenericConfigurationHolder> genericConfigurationEntry : genericConfigurationPoints.entrySet())
+      for (Entry<GenericIdentifier, GenericConfigurationHolder> genericConfigurationEntry : genericConfigurationPoints.entrySet())
       {
          Class<? extends Annotation> producerScope = Dependent.class;
          for (Annotation annotation : genericConfigurationEntry.getValue().getAnnotated().getAnnotations())
@@ -496,24 +508,19 @@ public class GenericBeanExtension implements Extension
             }
          }
          GenericConfigurationHolder genericConfigurationHolder = genericConfigurationEntry.getValue();
-         Annotation genericConfiguration = genericConfigurationEntry.getKey();
-         Set<Annotation> qualifiers = new HashSet<Annotation>();
-         qualifiers.addAll(Beans.getQualifiers(beanManager, genericConfigurationEntry.getValue().getAnnotated().getAnnotations()));
-         if (qualifiers.isEmpty())
-         {
-            qualifiers.add(DefaultLiteral.INSTANCE);
-         }
-         Class<? extends Annotation> genericConfigurationType = genericConfiguration.annotationType();
+         GenericIdentifier identifier = genericConfigurationEntry.getKey();
+
+         Class<? extends Annotation> genericConfigurationType = identifier.getAnnotationType();
          if (!genericBeans.containsKey(genericConfigurationType))
          {
             throw new IllegalStateException("No generic bean definition exists for " + genericConfigurationType + ", but a generic producer does: " + genericConfigurationHolder.getAnnotated());
          }
          // Add a generic configuration bean for each generic configuration producer (allows us to inject the generic configuration annotation back into the generic bean)
-         event.addBean(createGenericConfigurationBean(beanManager, genericConfiguration, qualifiers));
+         event.addBean(createGenericConfigurationBean(beanManager, identifier));
 
          // Register the GenericProduct bean
 
-         event.addBean(createGenericProductAnnotatedMemberBean(beanManager, genericConfiguration, qualifiers));
+         event.addBean(createGenericProductAnnotatedMemberBean(beanManager, identifier));
          
          boolean alternative = genericConfigurationHolder.getAnnotated().isAnnotationPresent(Alternative.class);
          Class<?> javaClass = genericConfigurationHolder.getJavaClass();
@@ -527,7 +534,7 @@ public class GenericBeanExtension implements Extension
                {
                   scopeOverride = producerScope;
                }
-               event.addBean(createGenericProducerMethod(holder, genericConfiguration, beanManager, scopeOverride,alternative,javaClass));
+               event.addBean(createGenericProducerMethod(holder, identifier, beanManager, scopeOverride, alternative, javaClass));
             }
          }
          if (genericBeanProducerFields.containsKey(genericConfigurationType))
@@ -539,14 +546,14 @@ public class GenericBeanExtension implements Extension
                {
                   scopeOverride = producerScope;
                }
-               event.addBean(createGenericProducerField(holder.getBean(), genericConfiguration, holder.getField(), beanManager, scopeOverride, alternative, javaClass));
+               event.addBean(createGenericProducerField(holder.getBean(), identifier, holder.getField(), beanManager, scopeOverride, alternative, javaClass));
             }
          }
          if (genericBeanObserverMethods.containsKey(genericConfigurationType))
          {
             for (ObserverMethodHolder<?, ?> holder : genericBeanObserverMethods.get(genericConfigurationType))
             {
-               event.addObserverMethod(createGenericObserverMethod(holder.getObserverMethod(), genericConfiguration, holder.getMethod(), null, beanManager));
+               event.addObserverMethod(createGenericObserverMethod(holder.getObserverMethod(), identifier, holder.getMethod(), null, beanManager));
             }
 
          }
@@ -579,7 +586,7 @@ public class GenericBeanExtension implements Extension
             {
                scopeOverride = producerScope;
             }
-            Bean<?> genericBean = createGenericBean(genericBeanHolder, genericConfiguration, beanManager, scopeOverride, alternative, javaClass);
+            Bean<?> genericBean = createGenericBean(genericBeanHolder, identifier, beanManager, scopeOverride, alternative, javaClass);
             event.addBean(genericBean);
          }
       }
@@ -604,11 +611,12 @@ public class GenericBeanExtension implements Extension
       }
    }
 
-   private Bean<?> createGenericConfigurationBean(BeanManager beanManager, final Annotation genericConfiguration, Set<Annotation> qualifiers)
+   private Bean<?> createGenericConfigurationBean(BeanManager beanManager, final GenericIdentifier identifier)
    {
       // We don't have a bean created for this generic configuration annotation. Create it, store it to be added later
       // TODO make this passivation capable?
-      BeanBuilder<Annotation> builder = new BeanBuilder<Annotation>(beanManager).beanClass(genericConfiguration.annotationType()).types(Arrays2.<Type> asSet(genericConfiguration.annotationType(), Object.class)).scope(Dependent.class).qualifiers(qualifiers).beanLifecycle(new ContextualLifecycle<Annotation>()
+      Set<Annotation> qualifiers = getQualifiers(beanManager, identifier, identifier.getQualifiers());
+      BeanBuilder<Annotation> builder = new BeanBuilder<Annotation>(beanManager).beanClass(identifier.getAnnotationType()).types(Arrays2.<Type> asSet(identifier.getAnnotationType(), Object.class)).scope(Dependent.class).qualifiers(qualifiers).beanLifecycle(new ContextualLifecycle<Annotation>()
       {
 
          public void destroy(Bean<Annotation> bean, Annotation arg0, CreationalContext<Annotation> arg1)
@@ -618,19 +626,19 @@ public class GenericBeanExtension implements Extension
 
          public Annotation create(Bean<Annotation> bean, CreationalContext<Annotation> arg0)
          {
-            return genericConfiguration;
+            return identifier.getConfiguration();
          }
       });
       return builder.create();
    }
    
-   private Bean<Annotated> createGenericProductAnnotatedMemberBean(BeanManager beanManager, final Annotation genericConfiguration, Set<Annotation> qualifiers)
+   private Bean<Annotated> createGenericProductAnnotatedMemberBean(BeanManager beanManager, final GenericIdentifier identifier)
    {
       @SuppressWarnings("unchecked")
-      final GenericConfigurationHolder holder = genericConfigurationPoints.get(genericConfiguration);
+      final GenericConfigurationHolder holder = genericConfigurationPoints.get(identifier);
 
       // TODO make this passivation capable?
-      BeanBuilder<Annotated> builder = new BeanBuilder<Annotated>(beanManager).beanClass(AnnotatedMember.class).qualifiers(Collections.<Annotation> singleton(annotatedMemberInjectionProvider.get(genericConfiguration))).beanLifecycle(new ContextualLifecycle<Annotated>()
+      BeanBuilder<Annotated> builder = new BeanBuilder<Annotated>(beanManager).beanClass(AnnotatedMember.class).qualifiers(Collections.<Annotation> singleton(annotatedMemberInjectionProvider.get(identifier))).beanLifecycle(new ContextualLifecycle<Annotated>()
       {
 
          public void destroy(Bean<Annotated> bean, Annotated instance, CreationalContext<Annotated> ctx)
@@ -646,37 +654,37 @@ public class GenericBeanExtension implements Extension
       return builder.create();
    }
 
-   private <X> Bean<X> createGenericBean(BeanHolder<X> holder, Annotation genericConfiguration, BeanManager beanManager, Class<? extends Annotation> scopeOverride, boolean alternative, Class<?> beanClass)
+   private <X> Bean<X> createGenericBean(BeanHolder<X> holder, GenericIdentifier identifier, BeanManager beanManager, Class<? extends Annotation> scopeOverride, boolean alternative, Class<?> beanClass)
    {
-      Set<Annotation> declaringBeanQualifiers = getQualifiers(beanManager, genericConfiguration, Collections.EMPTY_SET);
-      return new GenericManagedBean<X>(holder.getBean(), genericConfiguration, (InjectionTarget<X>) genericInjectionTargets.get(holder.getType()), holder.getType(), declaringBeanQualifiers, scopeOverride, annotatedMemberInjectionProvider, alternative, beanClass, beanManager);
+      Set<Annotation> qualifiers = getQualifiers(beanManager, identifier, Collections.<Annotation> emptySet());
+      return new GenericManagedBean<X>(holder.getBean(), identifier, (InjectionTarget<X>) genericInjectionTargets.get(holder.getType()), holder.getType(), qualifiers, scopeOverride, annotatedMemberInjectionProvider, alternative, beanClass, beanManager);
    }
 
-   private <X, T> Bean<T> createGenericProducerMethod(ProducerMethodHolder<X, T> holder, Annotation genericConfiguration, BeanManager beanManager, Class<? extends Annotation> scopeOverride, boolean alternative, Class<?> javaClass)
+   private <X, T> Bean<T> createGenericProducerMethod(ProducerMethodHolder<X, T> holder, GenericIdentifier identifier, BeanManager beanManager, Class<? extends Annotation> scopeOverride, boolean alternative, Class<?> javaClass)
    {
-      Set<Annotation> qualifiers = getQualifiers(beanManager, genericConfiguration, holder.getBean().getQualifiers());
-      Set<Annotation> declaringBeanQualifiers = getQualifiers(beanManager, genericConfiguration, Collections.EMPTY_SET);
-      return new GenericProducerMethod<T, X>(holder.getBean(), genericConfiguration, holder.getProducerMethod(), holder.getDisposerMethod(), qualifiers, declaringBeanQualifiers, scopeOverride, alternative, javaClass, beanManager);
+      Set<Annotation> qualifiers = getQualifiers(beanManager, identifier, holder.getBean().getQualifiers());
+      Set<Annotation> declaringBeanQualifiers = getQualifiers(beanManager, identifier, Collections.<Annotation> emptySet());
+      return new GenericProducerMethod<T, X>(holder.getBean(), identifier, holder.getProducerMethod(), holder.getDisposerMethod(), qualifiers, declaringBeanQualifiers, scopeOverride, alternative, javaClass, beanManager);
    }
 
    @SuppressWarnings("unchecked")
-   public Set<Annotation> getQualifiers(BeanManager beanManager, Annotation genericConfiguration, Iterable<Annotation> annotations)
+   public Set<Annotation> getQualifiers(BeanManager beanManager, GenericIdentifier identifier, Iterable<Annotation> annotations)
    {
-      return Beans.getQualifiers(beanManager, genericConfigurationPoints.get(genericConfiguration).getAnnotated().getAnnotations(), annotations);
+      return Beans.getQualifiers(beanManager, genericConfigurationPoints.get(identifier).getAnnotated().getAnnotations(), annotations);
    }
 
-   private <X, T> ObserverMethod<T> createGenericObserverMethod(ObserverMethod<T> originalObserverMethod, Annotation genericConfiguration, AnnotatedMethod<X> method, Bean<?> genericBean, BeanManager beanManager)
+   private <X, T> ObserverMethod<T> createGenericObserverMethod(ObserverMethod<T> originalObserverMethod, GenericIdentifier identifier, AnnotatedMethod<X> method, Bean<?> genericBean, BeanManager beanManager)
    {
-      Set<Annotation> qualifiers = getQualifiers(beanManager, genericConfiguration, originalObserverMethod.getObservedQualifiers());
-      Set<Annotation> declaringBeanQualifiers = getQualifiers(beanManager, genericConfiguration, Collections.EMPTY_SET);
-      return new GenericObserverMethod<T, X>(originalObserverMethod, method, genericConfiguration, qualifiers, declaringBeanQualifiers, genericBean, beanManager);
+      Set<Annotation> qualifiers = getQualifiers(beanManager, identifier, originalObserverMethod.getObservedQualifiers());
+      Set<Annotation> declaringBeanQualifiers = getQualifiers(beanManager, identifier, Collections.<Annotation> emptySet());
+      return new GenericObserverMethod<T, X>(originalObserverMethod, method, identifier.getConfiguration(), qualifiers, declaringBeanQualifiers, genericBean, beanManager);
    }
 
-   private <X, T> Bean<T> createGenericProducerField(Bean<T> originalBean, Annotation genericConfiguration, AnnotatedField<X> field, BeanManager beanManager, Class<? extends Annotation> scopeOverride, boolean alternative, Class<?> javaClass)
+   private <X, T> Bean<T> createGenericProducerField(Bean<T> originalBean, GenericIdentifier identifier, AnnotatedField<X> field, BeanManager beanManager, Class<? extends Annotation> scopeOverride, boolean alternative, Class<?> javaClass)
    {
-      Set<Annotation> qualifiers = getQualifiers(beanManager, genericConfiguration, originalBean.getQualifiers());
-      Set<Annotation> declaringBeanQualifiers = getQualifiers(beanManager, genericConfiguration, Collections.EMPTY_SET);
-      return new GenericProducerField<T, X>(originalBean, genericConfiguration, field, qualifiers, declaringBeanQualifiers, scopeOverride, alternative, javaClass, beanManager);
+      Set<Annotation> declaringBeanQualifiers = getQualifiers(beanManager, identifier, originalBean.getQualifiers());
+      Set<Annotation> qualifiers = getQualifiers(beanManager, identifier, field.getAnnotations());
+      return new GenericProducerField<T, X>(originalBean, identifier, field, declaringBeanQualifiers, qualifiers, scopeOverride, alternative, javaClass, beanManager);
    }
 
    void cleanup(@Observes AfterDeploymentValidation event)

--- a/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericIdentifier.java
+++ b/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericIdentifier.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.seam.solder.bean.generic;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+/**
+ * Uniquely identifies a generic bean set
+ * 
+ * @author Stuart Douglas
+ * 
+ */
+public class GenericIdentifier
+{
+
+   private final Set<Annotation> qualifiers;
+   private final Annotation configuration;
+
+   @Override
+   public String toString()
+   {
+      return "GenericIdentifier [configuration=" + configuration + ", qualifiers=" + qualifiers + "]";
+   }
+
+   @Override
+   public int hashCode()
+   {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((configuration == null) ? 0 : configuration.hashCode());
+      result = prime * result + ((qualifiers == null) ? 0 : qualifiers.hashCode());
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object obj)
+   {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      GenericIdentifier other = (GenericIdentifier) obj;
+      if (configuration == null)
+      {
+         if (other.configuration != null)
+            return false;
+      }
+      else if (!configuration.equals(other.configuration))
+         return false;
+      if (qualifiers == null)
+      {
+         if (other.qualifiers != null)
+            return false;
+      }
+      else if (!qualifiers.equals(other.qualifiers))
+         return false;
+      return true;
+   }
+
+   public GenericIdentifier(Set<Annotation> qualifiers, Annotation configuration)
+   {
+      this.qualifiers = qualifiers;
+      this.configuration = configuration;
+   }
+
+   public Set<Annotation> getQualifiers()
+   {
+      return qualifiers;
+   }
+
+   public Class<? extends Annotation> getAnnotationType()
+   {
+      return configuration.annotationType();
+   }
+
+   public Annotation getConfiguration()
+   {
+      return configuration;
+   }
+
+}

--- a/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericManagedBean.java
+++ b/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericManagedBean.java
@@ -46,9 +46,9 @@ class GenericManagedBean<T> extends AbstactGenericBean<T>
    private final Map<AnnotatedField<? super T>, InjectionPoint> injectedFields;
    private final Class<? extends Annotation> scopeOverride;
 
-   GenericManagedBean(Bean<T> originalBean, Annotation genericConfiguration, InjectionTarget<T> injectionTarget, AnnotatedType<T> type, Set<Annotation> qualifiers, Class<? extends Annotation> scopeOverride, Synthetic.Provider annotatedMemberSyntheticProvider, boolean alternative, Class<?> beanClass, BeanManager beanManager)
+   GenericManagedBean(Bean<T> originalBean, GenericIdentifier identifier, InjectionTarget<T> injectionTarget, AnnotatedType<T> type, Set<Annotation> qualifiers, Class<? extends Annotation> scopeOverride, Synthetic.Provider annotatedMemberSyntheticProvider, boolean alternative, Class<?> beanClass, BeanManager beanManager)
    {
-      super(originalBean, qualifiers, genericConfiguration, Annotateds.createTypeId(type), alternative, beanClass, beanManager);
+      super(originalBean, qualifiers, identifier, Annotateds.createTypeId(type), alternative, beanClass, beanManager);
       this.injectionTarget = injectionTarget;
       this.injectedFields = new HashMap<AnnotatedField<? super T>, InjectionPoint>();
       this.scopeOverride = scopeOverride;
@@ -60,7 +60,7 @@ class GenericManagedBean<T> extends AbstactGenericBean<T>
          {
             if (AnnotatedMember.class.isAssignableFrom(field.getJavaMember().getType()))
             {
-               injectedFields.put(field, new ImmutableInjectionPoint(field, Collections.<Annotation> singleton(annotatedMemberSyntheticProvider.get(genericConfiguration)), this, false, false));
+               injectedFields.put(field, new ImmutableInjectionPoint(field, Collections.<Annotation> singleton(annotatedMemberSyntheticProvider.get(identifier)), this, false, false));
             }
             else
             {

--- a/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericProducerField.java
+++ b/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericProducerField.java
@@ -34,9 +34,9 @@ class GenericProducerField<T, X> extends AbstractGenericProducerBean<T>
 
    private final AnnotatedField<X> field;
 
-   GenericProducerField(Bean<T> originalBean, Annotation genericConfiguration, AnnotatedField<X> field, Set<Annotation> qualifiers, Set<Annotation> declaringBeanQualifiers, Class<? extends Annotation> scopeOverride, boolean alternative, Class<?> declaringBeanClass, BeanManager beanManager)
+   GenericProducerField(Bean<T> originalBean, GenericIdentifier identifier, AnnotatedField<X> field, Set<Annotation> qualifiers, Set<Annotation> declaringBeanQualifiers, Class<? extends Annotation> scopeOverride, boolean alternative, Class<?> declaringBeanClass, BeanManager beanManager)
    {
-      super(originalBean, genericConfiguration, qualifiers, declaringBeanQualifiers, scopeOverride, Annotateds.createFieldId(field), alternative, declaringBeanClass, beanManager);
+      super(originalBean, identifier, qualifiers, declaringBeanQualifiers, scopeOverride, Annotateds.createFieldId(field), alternative, declaringBeanClass, beanManager);
       this.field = field;
    }
 

--- a/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericProducerMethod.java
+++ b/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericProducerMethod.java
@@ -21,6 +21,7 @@ import static org.jboss.seam.solder.bean.Beans.createInjectionPoints;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -34,6 +35,7 @@ import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.InjectionPoint;
 
 import org.jboss.seam.solder.bean.ImmutableInjectionPoint;
+import org.jboss.seam.solder.reflection.Synthetic;
 import org.jboss.seam.solder.reflection.annotated.Annotateds;
 import org.jboss.seam.solder.reflection.annotated.InjectableMethod;
 
@@ -98,6 +100,19 @@ public class GenericProducerMethod<T, X> extends AbstractGenericProducerBean<T>
          Set<Annotation> newQualifiers = new HashSet<Annotation>();
          newQualifiers.addAll(quals);
          newQualifiers.addAll(injectionPoint.getQualifiers());
+         Iterator<Annotation> it = newQualifiers.iterator();
+         while (it.hasNext())
+         {
+            Annotation annotation = it.next();
+            if (annotation.annotationType().equals(Synthetic.class))
+            {
+               it.remove();
+            }
+            else if (annotation.annotationType().equals(GenericMarker.class))
+            {
+               it.remove();
+            }
+         }
          return new ImmutableInjectionPoint((AnnotatedParameter<?>) anotated, newQualifiers, injectionPoint.getBean(), injectionPoint.isTransient(), injectionPoint.isDelegate());
       }
       return injectionPoint;

--- a/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericProducerMethod.java
+++ b/impl/src/main/java/org/jboss/seam/solder/bean/generic/GenericProducerMethod.java
@@ -43,9 +43,9 @@ public class GenericProducerMethod<T, X> extends AbstractGenericProducerBean<T>
    private final InjectableMethod<X> producerMethod;
    private final InjectableMethod<X> disposerMethod;
 
-   GenericProducerMethod(Bean<T> originalBean, Annotation genericConfiguration, AnnotatedMethod<X> method, AnnotatedMethod<X> disposerMethod, final Set<Annotation> qualifiers, final Set<Annotation> genericBeanQualifiers, Class<? extends Annotation> scopeOverride, boolean alternative, Class<?> declaringBeanClass, BeanManager beanManager)
+   GenericProducerMethod(Bean<T> originalBean, GenericIdentifier identifier, AnnotatedMethod<X> method, AnnotatedMethod<X> disposerMethod, final Set<Annotation> qualifiers, final Set<Annotation> genericBeanQualifiers, Class<? extends Annotation> scopeOverride, boolean alternative, Class<?> declaringBeanClass, BeanManager beanManager)
    {
-      super(originalBean, genericConfiguration, qualifiers, genericBeanQualifiers, scopeOverride, Annotateds.createCallableId(method), alternative, declaringBeanClass, beanManager);
+      super(originalBean, identifier, qualifiers, genericBeanQualifiers, scopeOverride, Annotateds.createCallableId(method), alternative, declaringBeanClass, beanManager);
       List<InjectionPoint> injectionPoints = createInjectionPoints(method, this, beanManager);
       List<InjectionPoint> wrappedInjectionPoints = new ArrayList<InjectionPoint>();
       for (InjectionPoint injectionPoint : injectionPoints)

--- a/impl/src/main/java/org/jboss/seam/solder/reflection/Synthetic.java
+++ b/impl/src/main/java/org/jboss/seam/solder/reflection/Synthetic.java
@@ -16,7 +16,6 @@
  */
 package org.jboss.seam.solder.reflection;
 
-import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.HashMap;
@@ -87,15 +86,15 @@ public @interface Synthetic
    public static class Provider
    {
 
-      //Map of generic Annotation instance to a SyntheticQualifier
-      private final Map<Annotation, Synthetic> synthetics;
+      // Map of generic Object to a SyntheticQualifier
+      private final Map<Object, Synthetic> synthetics;
       private final String namespace;
 
       private AtomicLong count;
 
       public Provider(String namespace)
       {
-         this.synthetics = new HashMap<Annotation, Synthetic>();
+         this.synthetics = new HashMap<Object, Synthetic>();
          this.namespace = namespace;
          this.count = new AtomicLong();
       }
@@ -107,16 +106,16 @@ public @interface Synthetic
        * @param annotation
        * @return
        */
-      public Synthetic get(Annotation annotation)
+      public Synthetic get(Object object)
       {
          // This may give us data races, but these don't matter as Annotation use it's type and it's members values
          // for equality, it does not use instance equality.
          // Note that count is atomic
-         if (!synthetics.containsKey(annotation))
+         if (!synthetics.containsKey(object))
          {
-            synthetics.put(annotation, new Synthetic.SyntheticLiteral(namespace, count.getAndIncrement()));
+            synthetics.put(object, new Synthetic.SyntheticLiteral(namespace, count.getAndIncrement()));
          }
-         return synthetics.get(annotation);
+         return synthetics.get(object);
       }
 
       /**

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/Garply.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/Garply.java
@@ -39,6 +39,7 @@ public class Garply
 {
 
    static boolean disposerCalled = false;
+   static boolean mapDisposerCalled = false;
    
    @Inject
    @Generic
@@ -69,6 +70,11 @@ public class Garply
       Assert.assertEquals(waldo.getName(), waldoName);
    }
 
+   public void dispose(@Disposes HashMap<String, String> map)
+   {
+      mapDisposerCalled = true;
+   }
+
    public Waldo getWaldo()
    {
       return waldo;
@@ -77,6 +83,11 @@ public class Garply
    public static boolean isDisposerCalled()
    {
       return disposerCalled;
+   }
+
+   public static boolean isMapDisposerCalled()
+   {
+      return mapDisposerCalled;
    }
 
 }

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/GenericProductTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/GenericProductTest.java
@@ -20,6 +20,8 @@ import static org.jboss.seam.solder.test.util.Deployments.baseDeployment;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.util.HashMap;
+
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
@@ -113,5 +115,11 @@ public class GenericProductTest
       manager.getReference(bean, String.class, ctx);
       ctx.release();
       Assert.assertTrue(Garply.disposerCalled);
+
+      bean = manager.resolve(manager.getBeans(HashMap.class, new FooLiteral(1)));
+      ctx = manager.createCreationalContext(bean);
+      manager.getReference(bean, String.class, ctx);
+      ctx.release();
+      Assert.assertTrue(Garply.isMapDisposerCalled());
    }
 }

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/Kitchen.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/Kitchen.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.seam.solder.test.bean.generic.method;
+
+public class Kitchen
+{
+   private final String size;
+
+   public Kitchen(String size)
+   {
+      this.size = size;
+   }
+
+   public String getSize()
+   {
+      return size;
+   }
+
+}

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/KitchenProducer.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/KitchenProducer.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.seam.solder.test.bean.generic.method;
+
+import javax.enterprise.inject.Produces;
+
+/**
+ * configures the {@link Room} generic beans
+ * 
+ * @author stuart
+ * 
+ */
+public class KitchenProducer
+{
+
+   @Foo(1)
+   @Produces
+   @Room
+   public Kitchen getBigKitchen()
+   {
+      return new Kitchen("big");
+   }
+
+   @Foo(2)
+   @Produces
+   @Room
+   public Kitchen getSmallKitchen()
+   {
+      return new Kitchen("small");
+   }
+
+}

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/QualifierOnlyGenericBeanTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/QualifierOnlyGenericBeanTest.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.seam.solder.test.bean.generic.method;
+
+import static org.jboss.seam.solder.test.util.Deployments.baseDeployment;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class QualifierOnlyGenericBeanTest
+{
+   
+   @Deployment
+   public static Archive<?> deployment()
+   {
+      return baseDeployment().addPackage(QualifierOnlyGenericBeanTest.class.getPackage());
+   }
+
+   @Inject
+   @Foo(1)
+   private Kitchen kitchen1;
+
+   @Inject
+   @Foo(2)
+   private Kitchen kitchen2;
+
+   @Inject
+   @Foo(1)
+   private Sink sink1;
+
+   @Inject
+   @Foo(2)
+   private Sink sink2;
+   
+
+   @Test
+   public void testGeneric()
+   {
+      
+      // Check that producer methods on generic beans are working
+      assertNotNull(kitchen1);
+      assertEquals("big", kitchen1.getSize());
+      assertNotNull(kitchen2);
+      assertEquals("small", kitchen2.getSize());
+      
+      assertNotNull(sink1);
+      assertEquals("big", sink1.getKitchen().getSize());
+      assertNotNull(sink2);
+      assertEquals("small", sink2.getKitchen().getSize());
+   }
+
+
+}

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/Room.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/Room.java
@@ -1,0 +1,20 @@
+package org.jboss.seam.solder.test.bean.generic.method;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.jboss.seam.solder.bean.generic.GenericType;
+
+@Retention(RUNTIME)
+@Target( { METHOD, FIELD, PARAMETER, TYPE })
+@GenericType(Kitchen.class)
+public @interface Room
+{
+
+}

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/Sink.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/Sink.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.seam.solder.test.bean.generic.method;
+
+import javax.inject.Inject;
+
+import org.jboss.seam.solder.bean.generic.Generic;
+import org.jboss.seam.solder.bean.generic.GenericConfiguration;
+
+@GenericConfiguration(Room.class)
+public class Sink
+{
+   @Inject
+   @Generic
+   private Kitchen kitchen;
+
+   public Kitchen getKitchen()
+   {
+      return kitchen;
+   }
+}


### PR DESCRIPTION
This removes the need for a unique configuration annotation. An annotation is still required, however it does not need to be unique, or have any members, making it more of a 'marker' annotation that anything else. It would be possible to remove the need for this annotation entirely, however I am not sure if that is a good idea.

I think the docs for this need to be expanded, and should probably have another example added. Although that will probably have to wait till next release.
