### PR TITLE
code-coverage for seam-solder

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -360,6 +360,33 @@
             </plugins>
          </build>
       </profile>
+      <profile>
+         <id>code-coverage</id>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.codehaus.mojo</groupId>
+                  <artifactId>emma-maven-plugin</artifactId>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-dependency-plugin</artifactId>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-antrun-plugin</artifactId>
+               </plugin>
+               <plugin>
+                  <groupId>org.sonatype.maven.plugin</groupId>
+                  <artifactId>emma4it-maven-plugin</artifactId>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 
    <properties>
       <seam.version>3.0.0.b06</seam.version>
+      <emma.version>2.0.5312</emma.version>
    </properties>
 
    <!-- Import the BOMs -->
@@ -137,6 +138,143 @@
                </snapshots>
             </pluginRepository>
          </pluginRepositories>
+      </profile>
+      <profile>
+         <id>code-coverage</id>
+         <build>
+            <pluginManagement>
+               <plugins>
+                  <plugin>
+                     <groupId>org.codehaus.mojo</groupId>
+                     <artifactId>emma-maven-plugin</artifactId>
+                     <executions>
+                        <execution>
+                           <id>instrumentation</id>
+                           <phase>process-classes</phase>
+                           <goals>
+                              <goal>instrument</goal>
+                           </goals>
+                           <configuration>
+                              <verbose>true</verbose>
+                           </configuration>
+                        </execution>
+                     </executions>
+                  </plugin>
+                  <plugin>
+                     <groupId>org.apache.maven.plugins</groupId>
+                     <artifactId>maven-surefire-plugin</artifactId>
+                     <configuration>
+                        <classesDirectory>${project.build.directory}/classes</classesDirectory>
+                     </configuration>
+                     <executions>
+                        <execution>
+                           <id>surefire-it</id>
+                           <phase>integration-test</phase>
+                           <goals>
+                              <goal>test</goal>
+                           </goals>
+                        </execution>
+                     </executions>
+                  </plugin>
+                  <plugin>
+                     <groupId>org.apache.maven.plugins</groupId>
+                     <artifactId>maven-dependency-plugin</artifactId>
+                     <executions>
+                        <execution>
+                           <id>deploy-emma-jar</id>
+                           <phase>process-test-sources</phase>
+                           <goals>
+                              <goal>copy</goal>
+                           </goals>
+                           <configuration>
+                              <artifactItems>
+                                 <artifactItem>
+                                    <groupId>emma</groupId>
+                                    <artifactId>emma</artifactId>
+                                    <version>${emma.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${env.JBOSS_HOME}/server/default/lib</outputDirectory>
+                                 </artifactItem>
+                              </artifactItems>
+                           </configuration>
+                        </execution>
+                     </executions>
+                  </plugin>
+                  <plugin>
+                     <groupId>org.apache.maven.plugins</groupId>
+                     <artifactId>maven-antrun-plugin</artifactId>
+                     <executions>
+                        <execution>
+                           <id>complete classpath for tests</id>
+                           <phase>process-classes</phase>
+                           <goals>
+                              <goal>run</goal>
+                           </goals>
+                           <configuration>
+                              <tasks>
+                                 <echo message="Copy instrumented classes to the regular classes dir" />
+                                 <delete dir="${project.build.directory}/classes" />
+                                 <mkdir dir="${project.build.directory}/classes" />
+                                 <copy todir="${project.build.directory}/classes" overwrite="true">
+                                    <fileset dir="${project.build.directory}/generated-classes/emma/classes">
+                                       <include name="**/*"/>
+                                    </fileset>
+                                 </copy>
+                              </tasks>
+                           </configuration>
+                        </execution>
+                        <execution>
+                           <id>retrieve-coverage-file</id>
+                           <phase>post-integration-test</phase>
+                           <goals>
+                              <goal>run</goal>
+                           </goals>
+                           <configuration>
+                              <tasks>
+                                 <move file="${env.JBOSS_HOME}/bin/coverage.ec"
+                                       todir="${basedir}" failonerror="false" verbose="true"/>
+                              </tasks>
+                           </configuration>
+                        </execution>
+                        <execution>
+                           <id>remove-coverage-files</id>
+                           <phase>verify</phase>
+                           <goals>
+                              <goal>run</goal>
+                           </goals>
+                           <configuration>
+                              <tasks>
+                                 <delete file="${basedir}/transaction.log" failonerror="false" />
+                                 <delete file="${basedir}/coverage.ec" failonerror="false" />
+                              </tasks>
+                           </configuration>
+                        </execution>
+                     </executions>
+                  </plugin>
+                  <plugin>
+                     <groupId>org.sonatype.maven.plugin</groupId>
+                     <artifactId>emma4it-maven-plugin</artifactId>
+                     <executions>
+                        <execution>
+                           <id>report</id>
+                           <phase>post-integration-test</phase>
+                           <goals>
+                              <goal>report</goal>
+                           </goals>
+                           <configuration>
+                              <sourceSets>
+                                 <sourceSet>
+                                    <directory>${project.build.sourceDirectory}</directory>
+                                 </sourceSet>
+                              </sourceSets>
+                           </configuration>
+                        </execution>
+                     </executions>
+                  </plugin>
+               </plugins>
+            </pluginManagement>
+         </build>
       </profile>
    </profiles>
 


### PR DESCRIPTION
Hi, this commit contains a code-coverage maven profile that will create the reports. It should run incontainer, thus the command for creating the coverage report is the following:
mvn clean install -Pincontainer,code-coverage -Demma.jar.file=${path.to.emma.jar} -Dmaven.test.failure.ignore=true 
Also JBOSS_HOME env property has to be set.
The results then can be found in impl/target/site/emma/index.html. The emma.jar.file can be found for example at https://svn.devel.redhat.com/repos/seam/trunk/qa/conf/seam3/emma.jar.  Note that it's needed to specify the emma jar file because it has to be copied to the app server. That's how it works when trying to retrieve code-coverage reports from running JBossAS. Currently there are 2 tests failing but it's not a problem of code-coverage profile.
