### PR TITLE
fix code-coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
                      <executions>
                         <execution>
                            <id>instrumentation</id>
-                           <phase>process-classes</phase>
+                           <phase>process-test-classes</phase>
                            <goals>
                               <goal>instrument</goal>
                            </goals>
@@ -208,7 +208,7 @@
                      <executions>
                         <execution>
                            <id>complete classpath for tests</id>
-                           <phase>process-classes</phase>
+                           <phase>process-test-classes</phase>
                            <goals>
                               <goal>run</goal>
                            </goals>


### PR DESCRIPTION
Hi Shane, 
when I recently tried to run the code-coverage you pushed into master, I was suddenly getting a compilation error while compiling tests for impl submodule. This was working about 1 month ago when I was creating the code-coverage profile but now it is not. It seems Emma has a bug in itself and cannot work perfectly with generics. So I had to modify the profile to not include the classes generated with emma to the classpath for test compiling. You can, of course, try to run it by yourself by running mvn clean install -Pincontainer,code-coverage -Dmaven.test.failure.ignore=true. The results will be in impl/target/site/emma/

The current coverage:
[class, %]          [method, %]         [block, %]                  [line, %]  
60%  (112/187)! 42%  (458/1103)!    43%  (8157/19074)!  44%  (1676.8/3846)! 
