### PR TITLE
add <distributable/> to META-INF/web-fragment.xml

### DIFF
--- a/impl/src/main/resources/META-INF/web-fragment.xml
+++ b/impl/src/main/resources/META-INF/web-fragment.xml
@@ -20,6 +20,8 @@
               xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd">
     <name>SeamSolder</name>
 
+    <distributable/>
+
     <listener>
         <listener-class>org.jboss.seam.solder.resourceLoader.servlet.ResourceListener</listener-class>
     </listener>


### PR DESCRIPTION
https://issues.jboss.org/browse/SOLDER-108

The semantics of the <distributable/> element in web.xml is such that all web fragments have to have one if the web application is supposed to be on the whole distributable.

From the JSR-315:

```
The web.xml resulting from the merge is considered <distributable>
only if all its web fragments are marked as <distributable> as well.
```

Therefore, Seam Solder web-fragment should contain the tag, indicating it can be used in a distributable web application. Otherwise, users are forced to edit the web-fragment.xml inside the jar, which is annoying, especially in a maven build environment.
