### PR TITLE
move to arquillian cr2 and add AS7 profile for integration tests

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -33,7 +33,7 @@
    <url>${project.parent.url}</url>
 
 	<properties>
-		<version.arquillian>1.0.0.Alpha5</version.arquillian>
+	    <version.jbossas7>7.0.0.Final</version.jbossas7>
 	</properties>
 
    <dependencies>
@@ -124,9 +124,8 @@
       </dependency>
 
       <dependency>
-         <groupId>org.jboss.arquillian</groupId>
-         <artifactId>arquillian-junit</artifactId>
-         <version>${version.arquillian}</version>
+         <groupId>org.jboss.arquillian.junit</groupId>
+         <artifactId>arquillian-junit-container</artifactId>
          <scope>test</scope>
       </dependency>
 
@@ -184,7 +183,6 @@
             <dependency>
                <groupId>org.jboss.arquillian.container</groupId>
                <artifactId>arquillian-weld-ee-embedded-1.1</artifactId>
-               <version>${version.arquillian}</version>
             </dependency>
             <dependency>
                <groupId>org.jboss.spec.javax.transaction</groupId>
@@ -237,7 +235,6 @@
             <dependency>
                <groupId>org.jboss.arquillian.container</groupId>
                <artifactId>arquillian-openwebbeans-embedded-1</artifactId>
-               <version>${version.arquillian}</version>
             </dependency>
 	        <dependency>
 	            <groupId>org.apache.openwebbeans</groupId>
@@ -306,18 +303,17 @@
          </build>
       </profile>
       <profile>
-         <id>incontainer</id>
+         <id>incontainer-jbossas6-managed</id>
          <activation>
             <activeByDefault>false</activeByDefault>
             <property>
-               <name>incontainer</name>
+               <name>incontainer-jbossas6-managed</name>
             </property>
          </activation>
          <dependencies>
             <dependency>
                <groupId>org.jboss.arquillian.container</groupId>
                <artifactId>arquillian-jbossas-managed-6</artifactId>
-               <version>${version.arquillian}</version>
             </dependency>
             <dependency>
                <groupId>org.jboss.jbossas</groupId>
@@ -336,18 +332,17 @@
          </dependencies>
       </profile>
       <profile>
-         <id>incontainer-remote</id>
+         <id>incontainer-jbossas6-remote</id>
          <activation>
             <activeByDefault>false</activeByDefault>
             <property>
-               <name>incontainer-remote</name>
+               <name>incontainer-jbossas6-remote</name>
             </property>
          </activation>
          <dependencies>
             <dependency>
                <groupId>org.jboss.arquillian.container</groupId>
                <artifactId>arquillian-jbossas-remote-6</artifactId>
-               <version>${version.arquillian}</version>
             </dependency>
             <dependency>
                <groupId>org.jboss.jbossas</groupId>
@@ -357,6 +352,42 @@
             <dependency>
                <groupId>org.jboss.weld</groupId>
                <artifactId>weld-core</artifactId>
+               <scope>test</scope>
+            </dependency>
+         </dependencies>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                     <parallel>none</parallel>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+ 
+      <profile>
+         <id>incontainer-jbossas7-remote</id>
+         <activation>
+            <activeByDefault>false</activeByDefault>
+            <property>
+               <name>incontainer-jbossas7-remote</name>
+            </property>
+         </activation>
+         <dependencies>
+            <dependency>
+               <groupId>org.jboss.as</groupId>
+               <artifactId>jboss-as-arquillian-container-remote</artifactId>
+               <version>${version.jbossas7}</version>
+               <scope>test</scope>
+            </dependency>
+
+            <dependency>
+               <groupId>org.jboss.naming</groupId>
+               <artifactId>jnp-client</artifactId>
+               <version>5.0.4.GA</version>
                <scope>test</scope>
             </dependency>
          </dependencies>
@@ -385,7 +416,6 @@
             <dependency>
                <groupId>org.jboss.arquillian.container</groupId>
                <artifactId>arquillian-glassfish-remote-3.1</artifactId>
-               <version>${version.arquillian}</version>
                <scope>test</scope>
             </dependency>
             <dependency>

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/defaultbean/DefaultBeanTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/defaultbean/DefaultBeanTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertEquals;
 import javax.enterprise.inject.spi.Extension;
 import javax.inject.Inject;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.seam.solder.logging.internal.Logger;
 import org.jboss.seam.solder.bean.Beans;

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/alternative/GenericBeanAlternativeTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/alternative/GenericBeanAlternativeTest.java
@@ -22,7 +22,7 @@ import javax.inject.Inject;
 
 import junit.framework.Assert;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/field/GenericBeanTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/field/GenericBeanTest.java
@@ -18,7 +18,7 @@ package org.jboss.seam.solder.test.bean.generic.field;
 
 import javax.inject.Inject;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/field/GenericBeanUnwrapTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/field/GenericBeanUnwrapTest.java
@@ -19,7 +19,7 @@ package org.jboss.seam.solder.test.bean.generic.field;
 import javax.inject.Inject;
 
 import junit.framework.Assert;
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/field/GenericProductTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/field/GenericProductTest.java
@@ -18,7 +18,7 @@ package org.jboss.seam.solder.test.bean.generic.field;
 
 import javax.inject.Inject;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/field/ObserversOnGenericBeanTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/field/ObserversOnGenericBeanTest.java
@@ -19,7 +19,7 @@ package org.jboss.seam.solder.test.bean.generic.field;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/field/ProducersOnGenericBeanTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/field/ProducersOnGenericBeanTest.java
@@ -18,7 +18,7 @@ package org.jboss.seam.solder.test.bean.generic.field;
 
 import javax.inject.Inject;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/GenericBeanTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/GenericBeanTest.java
@@ -18,7 +18,7 @@ package org.jboss.seam.solder.test.bean.generic.method;
 
 import javax.inject.Inject;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/GenericProductTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/GenericProductTest.java
@@ -25,7 +25,7 @@ import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Inject;
 
 import junit.framework.Assert;
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/ProducersOnGenericBeanTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/ProducersOnGenericBeanTest.java
@@ -21,8 +21,9 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/QualifierOnlyGenericBeanTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/bean/generic/method/QualifierOnlyGenericBeanTest.java
@@ -18,7 +18,7 @@ package org.jboss.seam.solder.test.bean.generic.method;
 
 import javax.inject.Inject;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/seam/solder/test/core/CoreTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/core/CoreTest.java
@@ -25,7 +25,7 @@ import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 
 import junit.framework.Assert;
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.seam.solder.core.CoreExtension;
 import org.jboss.seam.solder.core.VersionLoggerUtil;

--- a/impl/src/test/java/org/jboss/seam/solder/test/core/requires/RequiresTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/core/requires/RequiresTest.java
@@ -19,7 +19,7 @@ package org.jboss.seam.solder.test.core.requires;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.seam.solder.test.core.requires.beans.EnabledOptionalBean;
 import org.jboss.seam.solder.test.core.requires.beans.pkg.OptionalBeanWithPackageLevelDependencies;

--- a/impl/src/test/java/org/jboss/seam/solder/test/defaultbean/DefaultBeanTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/defaultbean/DefaultBeanTest.java
@@ -19,7 +19,7 @@ package org.jboss.seam.solder.test.defaultbean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.seam.solder.literal.DefaultLiteral;
 import org.jboss.shrinkwrap.api.spec.WebArchive;

--- a/impl/src/test/java/org/jboss/seam/solder/test/el/ElTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/el/ElTest.java
@@ -20,7 +20,7 @@ import javax.el.ExpressionFactory;
 import javax.inject.Inject;
 
 import com.sun.el.ExpressionFactoryImpl;
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.seam.solder.el.ELResolverProducer;
 import org.jboss.seam.solder.el.Expressions;
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.jboss.seam.solder.test.util.Deployments.baseDeployment;
-import static org.jboss.seam.solder.test.util.Deployments.targetContainerAdapterClass;
+// import static org.jboss.seam.solder.test.util.Deployments.targetContainerAdapterClass;
 
 @RunWith(Arquillian.class)
 public class ElTest {
@@ -41,8 +41,10 @@ public class ElTest {
 
     @Deployment
     public static Archive<?> deployment() {
+        // TODO: fix the hack
         // hack to work around container differences atm
-        boolean isEmbedded = targetContainerAdapterClass().getName().contains(".embedded");
+        //boolean isEmbedded = targetContainerAdapterClass().getName().contains(".embedded");
+        boolean isEmbedded = false;
 
         WebArchive war = baseDeployment().addPackage(ElTest.class.getPackage());
         if (isEmbedded) {

--- a/impl/src/test/java/org/jboss/seam/solder/test/logging/LoggerInjectionTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/logging/LoggerInjectionTest.java
@@ -22,9 +22,9 @@ import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.InjectionTarget;
 
 import junit.framework.Assert;
-import org.jboss.arquillian.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.seam.solder.test.util.Deployments;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/impl/src/test/java/org/jboss/seam/solder/test/logging/TypedMessageLoggerInjectionTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/logging/TypedMessageLoggerInjectionTest.java
@@ -19,7 +19,7 @@ package org.jboss.seam.solder.test.logging;
 
 import javax.enterprise.inject.Instance;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/seam/solder/test/messages/TypedMessageBundleInjectionTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/messages/TypedMessageBundleInjectionTest.java
@@ -17,7 +17,7 @@
 
 package org.jboss.seam.solder.test.messages;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/seam/solder/test/resourceLoader/ResourceLoaderTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/resourceLoader/ResourceLoaderTest.java
@@ -28,7 +28,7 @@ import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.seam.solder.resourceLoader.Resource;
 import org.jboss.seam.solder.resourceLoader.ResourceLoader;
@@ -39,7 +39,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.jboss.seam.solder.test.util.Deployments.baseDeployment;
-import static org.jboss.seam.solder.test.util.Deployments.targetContainerAdapterClass;
+// import static org.jboss.seam.solder.test.util.Deployments.targetContainerAdapterClass;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -47,9 +47,10 @@ import static org.junit.Assert.assertNotNull;
 public class ResourceLoaderTest {
     @Deployment
     public static Archive<?> deployment() {
+        // TODO: fix the hack
         // hack to work around container differences atm
-        boolean isEmbedded = targetContainerAdapterClass().getName().contains(".embedded");
-
+        //boolean isEmbedded = targetContainerAdapterClass().getName().contains(".embedded");
+        boolean isEmbedded = false;
         WebArchive war = baseDeployment().addPackage(ResourceLoaderTest.class.getPackage())
                 .addAsResource("com/acme/foo1")
                 .addAsResource("com/acme/foo2.properties");

--- a/impl/src/test/java/org/jboss/seam/solder/test/serviceHandler/ServiceHandlerTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/serviceHandler/ServiceHandlerTest.java
@@ -19,7 +19,7 @@ package org.jboss.seam.solder.test.serviceHandler;
 import javax.inject.Inject;
 
 import junit.framework.Assert;
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/seam/solder/test/unwraps/UnwrapsTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/unwraps/UnwrapsTest.java
@@ -19,7 +19,7 @@ package org.jboss.seam.solder.test.unwraps;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;

--- a/impl/src/test/java/org/jboss/seam/solder/test/util/AnnotationInspectorTest.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/util/AnnotationInspectorTest.java
@@ -24,7 +24,7 @@ import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 
-import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.seam.solder.reflection.AnnotationInspector;
 import org.jboss.seam.solder.reflection.annotated.AnnotatedTypeBuilder;

--- a/impl/src/test/java/org/jboss/seam/solder/test/util/Deployments.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/util/Deployments.java
@@ -16,24 +16,27 @@
  */
 package org.jboss.seam.solder.test.util;
 
-import org.jboss.arquillian.spi.client.container.DeployableContainer;
-import org.jboss.arquillian.spi.util.ServiceLoader;
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.arquillian.core.spi.ServiceLoader;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 public class Deployments {
+
     public static WebArchive baseDeployment() {
         return ShrinkWrap.create(WebArchive.class, "test.war")
                 .addAsLibraries(
-                        MavenArtifactResolver.resolve("org.jboss.seam.solder", "seam-solder-api"),
                         MavenArtifactResolver.resolve("org.jboss.seam.solder", "seam-solder"),
+                        MavenArtifactResolver.resolve("org.jboss.seam.solder", "seam-solder-api"),
                         MavenArtifactResolver.resolve("org.jboss.seam.solder", "seam-solder-logging"))
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
+    // TODO: Port this to the new ARQ API somehow
+    /*
     public static Class<? extends DeployableContainer> targetContainerAdapterClass() {
         ServiceLoader<DeployableContainer> l = ServiceLoader.load(DeployableContainer.class);
         return l.getProviders().iterator().next().getClass();
-    }
+    }*/
 }

--- a/impl/src/test/java/org/jboss/seam/solder/test/util/MavenArtifactResolver.java
+++ b/impl/src/test/java/org/jboss/seam/solder/test/util/MavenArtifactResolver.java
@@ -53,6 +53,7 @@ public class MavenArtifactResolver {
     }
 
     private final String classPathSeparatorRegex;
+    private final String versionSeparatorRegex;
     private final char fileSeparator;
     private final String groupId;
     private final String artifactId;
@@ -63,6 +64,7 @@ public class MavenArtifactResolver {
         this.artifactId = artifactId;
         this.classPath = classPath;
         this.classPathSeparatorRegex = "[^" + pathSeparator + "]*";
+        this.versionSeparatorRegex = "-[0-9]";
         this.fileSeparator = fileSeparator;
     }
 
@@ -133,7 +135,7 @@ public class MavenArtifactResolver {
      * classpath from the reactor.
      */
     private Matcher createUnqualifiedMatcher() {
-        Pattern p = Pattern.compile(classPathSeparatorRegex + Pattern.quote("target" + fileSeparator + artifactId) + classPathSeparatorRegex, Pattern.CASE_INSENSITIVE);
+        Pattern p = Pattern.compile(classPathSeparatorRegex + Pattern.quote("target" + fileSeparator + artifactId) + versionSeparatorRegex + classPathSeparatorRegex, Pattern.CASE_INSENSITIVE);
         return p.matcher(classPath);
     }
 


### PR DESCRIPTION
Update the integration test suite to new Arquillian and create an AS7-remote profile
1. get the arquillian version from parent
2. update to arquillian 1.0.0.CR2 / shrinkwrap API
3. workaround for a problem with MavenArtifactResolver resolving org.jboss.seam.solder:seam-solder as seam-solder-api-3.1.0.Beta1.jar, instead of seam-solder-3.1.0.Beta1.jar
4. removed (commented out) the targetContainerAdapterClass hack for now for now, as I couldn't figure out how to do it properly with the new API... 
