### PR TITLE
making the testsuite work for as7 managed, glassfish embedded and weld ee

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
       <module>api</module>
       <module>tooling</module>
       <module>impl</module>
+      <module>testsuite</module>
    </modules>
 
    <properties>

--- a/testsuite/internals/base/src/main/java/org/jboss/seam/solder/test/bean/defaultbean/DefaultBeanTest.java
+++ b/testsuite/internals/base/src/main/java/org/jboss/seam/solder/test/bean/defaultbean/DefaultBeanTest.java
@@ -18,33 +18,11 @@ package org.jboss.seam.solder.test.bean.defaultbean;
 
 import static org.junit.Assert.assertEquals;
 
-import javax.enterprise.inject.spi.Extension;
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.seam.logging.Category;
-import org.jboss.seam.solder.logging.internal.Logger;
-import org.jboss.seam.solder.bean.Beans;
-import org.jboss.seam.solder.bean.defaultbean.DefaultBeanExtension;
-import org.jboss.seam.solder.bean.generic.GenericBeanExtension;
-import org.jboss.seam.solder.beanManager.BeanManagerAware;
-import org.jboss.seam.solder.core.Client;
-import org.jboss.seam.solder.core.CoreExtension;
-import org.jboss.seam.solder.el.Resolver;
-import org.jboss.seam.solder.literal.DefaultLiteral;
-import org.jboss.seam.solder.logging.TypedMessageLoggerExtension;
-import org.jboss.seam.solder.messages.Messages;
-import org.jboss.seam.solder.reflection.Synthetic;
-import org.jboss.seam.solder.resourceLoader.ResourceLoader;
-import org.jboss.seam.solder.serviceHandler.ServiceHandlerExtension;
-import org.jboss.seam.solder.support.SolderMessages;
-import org.jboss.seam.solder.test.properties.ClassToIntrospect;
-import org.jboss.seam.solder.unwraps.UnwrapsExtension;
-import org.jboss.seam.solder.util.Sortable;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.seam.solder.test.util.Deployments;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,39 +41,8 @@ public class DefaultBeanTest {
 
     @Deployment(name = "DefaultBean")
     public static WebArchive createDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "test.war");
-        war.addPackage(DefaultBeanTest.class.getPackage());
-        war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
-        war.addAsLibrary(createSeamSolder());
-        return war;
-    }
-
-    /**
-     * Seam Solder TODO: there must be a better way to get Solder jar
-     */
-    public static JavaArchive createSeamSolder() {
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "solder.jar");
-
-        jar.addPackages(true, Beans.class.getPackage()); // .bean
-        jar.addPackages(true, BeanManagerAware.class.getPackage()); // .beanManager
-        jar.addPackages(true, Client.class.getPackage()); // .core
-        jar.addPackages(true, Resolver.class.getPackage()); // .el
-        jar.addPackages(true, DefaultLiteral.class.getPackage()); // .literal
-        jar.addPackages(true, Category.class.getPackage()); // .log
-        jar.addPackages(true, Messages.class.getPackage()); // .logging
-        jar.addPackages(true, ClassToIntrospect.class.getPackage()); // .properties
-        jar.addPackages(true, SolderMessages.class.getPackage()); // .messages
-        jar.addPackages(true, Synthetic.class.getPackage()); // .reflection
-        jar.addPackages(true, ResourceLoader.class.getPackage()); // .resourceLoader
-        jar.addPackages(true, ServiceHandlerExtension.class.getPackage()); // .serviceHandler
-        jar.addPackages(true, UnwrapsExtension.class.getPackage()); // .unwraps
-        jar.addPackages(true, Sortable.class.getPackage()); // .util
-        jar.addPackages(false, Logger.class.getPackage()); // org.jboss.seam.solder.logging.internal
-
-        jar.addAsServiceProvider(Extension.class, GenericBeanExtension.class, DefaultBeanExtension.class, CoreExtension.class,
-                UnwrapsExtension.class, TypedMessageLoggerExtension.class, ServiceHandlerExtension.class);
-        jar.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-        return jar;
+        return Deployments.baseDeployment()
+            .addPackage(DefaultBeanTest.class.getPackage());
     }
 
     @Test

--- a/testsuite/internals/base/src/main/java/org/jboss/seam/solder/test/bean/generic/alternative/GenericBeanAlternativeTest.java
+++ b/testsuite/internals/base/src/main/java/org/jboss/seam/solder/test/bean/generic/alternative/GenericBeanAlternativeTest.java
@@ -16,14 +16,14 @@
  */
 package org.jboss.seam.solder.test.bean.generic.alternative;
 
-import static org.jboss.seam.solder.test.util.Deployments.baseDeployment;
-
 import javax.inject.Inject;
 
 import junit.framework.Assert;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.seam.solder.test.util.MavenArtifactResolver;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,8 +32,13 @@ import org.junit.runner.RunWith;
 public class GenericBeanAlternativeTest {
     @Deployment(name = "GenericBeanAlternative")
     public static WebArchive deployment() {
-        return baseDeployment().addPackage(GenericBeanAlternativeTest.class.getPackage()).addAsWebInfResource(
-                "org/jboss/seam/solder/test/bean/generic/alternative/beans.xml", "beans.xml");
+        return ShrinkWrap.create(WebArchive.class, "test.war")
+            .addAsLibraries(
+                    MavenArtifactResolver.resolve("org.jboss.seam.solder", "seam-solder-api"),
+                    MavenArtifactResolver.resolve("org.jboss.seam.solder", "seam-solder"),
+                    MavenArtifactResolver.resolve("org.jboss.seam.solder", "seam-solder-logging"))        
+                .addPackage(GenericBeanAlternativeTest.class.getPackage())
+                .addAsWebInfResource("org/jboss/seam/solder/test/bean/generic/alternative/beans.xml", "beans.xml");
     }
 
     @Inject

--- a/testsuite/internals/base/src/main/java/org/jboss/seam/solder/test/el/ElTest.java
+++ b/testsuite/internals/base/src/main/java/org/jboss/seam/solder/test/el/ElTest.java
@@ -42,7 +42,8 @@ public class ElTest {
     @Deployment(name = "EL")
     public static Archive<?> deployment() {
         // hack to work around container differences atm
-        boolean isEmbedded = targetContainerAdapterClass().getName().contains(".embedded");
+        // boolean isEmbedded = targetContainerAdapterClass().getName().contains(".embedded");
+        boolean isEmbedded = false;
 
         WebArchive war = baseDeployment().addPackage(ElTest.class.getPackage());
         if (isEmbedded) {

--- a/testsuite/internals/base/src/main/java/org/jboss/seam/solder/test/messages/TypedMessageBundleInjectionTest.java
+++ b/testsuite/internals/base/src/main/java/org/jboss/seam/solder/test/messages/TypedMessageBundleInjectionTest.java
@@ -37,7 +37,8 @@ public class TypedMessageBundleInjectionTest {
     @Deployment(name = "TypedMessageBundleInjection")
     public static Archive<?> createDeployment() {
         return baseDeployment()
-                .addPackage(TypedMessageBundleInjectionTest.class.getPackage());
+                .addPackage(TypedMessageBundleInjectionTest.class.getPackage())
+                .addAsResource("org/jboss/seam/solder/test/messages/BirdMessages.i18n_fr.properties");
     }
 
     @Test

--- a/testsuite/internals/base/src/main/java/org/jboss/seam/solder/test/resourceLoader/ResourceLoaderTest.java
+++ b/testsuite/internals/base/src/main/java/org/jboss/seam/solder/test/resourceLoader/ResourceLoaderTest.java
@@ -48,7 +48,8 @@ public class ResourceLoaderTest {
     @Deployment(name = "ResourceLoader")
     public static Archive<?> deployment() {
         // hack to work around container differences atm
-        boolean isEmbedded = targetContainerAdapterClass().getName().contains(".embedded");
+        // boolean isEmbedded = targetContainerAdapterClass().getName().contains(".embedded");
+        boolean isEmbedded = false;
 
         WebArchive war = baseDeployment().addPackage(ResourceLoaderTest.class.getPackage())
                 .addAsResource("com/acme/foo1")

--- a/testsuite/internals/base/src/main/resources/jndi.properties
+++ b/testsuite/internals/base/src/main/resources/jndi.properties
@@ -1,4 +1,0 @@
-#jboss JNDI properties
-java.naming.factory.initial=org.jnp.interfaces.NamingContextFactory
-java.naming.provider.url=jnp://localhost:1099
-java.naming.factory.url.pkgs=org.jboss.naming:org.jnp.interfaces

--- a/testsuite/internals/glassfish/pom.xml
+++ b/testsuite/internals/glassfish/pom.xml
@@ -10,8 +10,8 @@
       <relativePath>../pom.xml</relativePath>
    </parent>
 
-   <artifactId>seam-solder-testsuite-integration-internals-jbossas</artifactId>
-   <name>Seam Solder Test Suite: Internals Integration Tests for JBoss AS</name>
+   <artifactId>seam-solder-testsuite-integration-internals-glassfish</artifactId>
+   <name>Seam Solder Test Suite: Internals Integration Tests for GlassFish</name>
    <packaging>jar</packaging>
 
    <dependencies>
@@ -95,51 +95,26 @@
                </execution>
             </executions>
          </plugin>
-
+      
          <!-- skip unit test run, tests to be executed during integration-test -->
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
                <skip>true</skip>
-               
             </configuration>
          </plugin>
-         
-         <!--plugin>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-               <execution>
-                  <id>unpack-base-tests</id>
-                  <phase>process-test-classes</phase>
-                  <goals>
-                     <goal>unpack</goal>
-                  </goals>
-                  <configuration>
-                     <artifactItems>
-                        <artifactItem>
-                           <groupId>org.jboss.seam.solder</groupId>
-                           <artifactId>seam-solder-testsuite-integration-internals-base</artifactId>
-                           <version>${project.version}</version>
-                           <type>jar</type>
-                           <outputDirectory>${project.build.directory}/test-classes/</outputDirectory>
-                        </artifactItem>
-                     </artifactItems>
-                  </configuration>
-               </execution>
-            </executions>
-         </plugin-->
       </plugins>
    </build>
 
    <profiles>
       <profile>
-         <id>jbossas-managed-7</id>
+         <id>glassfish-embedded-3.1</id>
          <activation>
             <activeByDefault>true</activeByDefault>
             <property>
                <name>arquillian</name>
-               <value>jbossas-managed-7</value>
+               <value>glassfish-embedded-3.1</value>
             </property>
          </activation>
          
@@ -147,7 +122,7 @@
          
             <dependency>
                <groupId>org.jboss.seam.test</groupId>
-               <artifactId>jbossas-managed-7</artifactId>
+               <artifactId>glassfish-embedded-3.1</artifactId>
                <type>pom</type>
                <scope>test</scope>
             </dependency>
@@ -156,33 +131,6 @@
          
          <build>
             <plugins>
-               <!-- Get AS and put into "target" -->
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-dependency-plugin</artifactId>
-                  <executions>
-                     <execution>
-                        <id>unpack-as7</id>
-                        <phase>process-test-classes</phase> <!-- So run before testing -->
-                        <goals>
-                           <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                           <artifactItems>
-                              <artifactItem>
-                                 <groupId>org.jboss.as</groupId>
-                                 <artifactId>jboss-as-dist</artifactId>
-                                 <version>${jbossas.7.version}</version>
-                                 <type>zip</type>
-                                 <overWrite>false</overWrite>
-                                 <outputDirectory>${project.build.directory}</outputDirectory>
-                              </artifactItem>
-                           </artifactItems>
-                        </configuration>
-                     </execution>
-                  </executions>
-               </plugin>
-               
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
@@ -202,7 +150,7 @@
                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
                            <trimStackTrace>false</trimStackTrace>
                            <printSummary>true</printSummary>
-                           <!-- forkMode>always</forkMode -->
+                           <!--forkMode>always</forkMode-->
                         </configuration>
                      </execution>
                   </executions>

--- a/testsuite/internals/glassfish/src/test/resources/arquillian.xml
+++ b/testsuite/internals/glassfish/src/test/resources/arquillian.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  JBoss, Home of Professional Open Source
+  Copyright 2010, Red Hat Middleware LLC, and individual contributors
+  by the @authors tag. See the copyright.txt in the distribution for a
+  full listing of individual contributors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+   <engine>
+      <property name="deploymentExportPath">target/</property>
+   </engine>
+</arquillian>

--- a/testsuite/internals/pom.xml
+++ b/testsuite/internals/pom.xml
@@ -17,6 +17,7 @@
    <modules>
       <module>base</module>
       <module>jbossas</module>
-      <!--module>weld-ee-embedded</module-->
+      <module>glassfish</module>
+      <module>weld-ee-embedded</module>
    </modules>
 </project>

--- a/testsuite/internals/weld-ee-embedded/pom.xml
+++ b/testsuite/internals/weld-ee-embedded/pom.xml
@@ -10,8 +10,8 @@
       <relativePath>../pom.xml</relativePath>
    </parent>
 
-   <artifactId>seam-solder-testsuite-integration-internals-jbossas</artifactId>
-   <name>Seam Solder Test Suite: Internals Integration Tests for JBoss AS</name>
+   <artifactId>seam-solder-testsuite-integration-internals-weld-ee-embedded</artifactId>
+   <name>Seam Solder Test Suite: Internals Integration Tests for Weld EE Embedded</name>
    <packaging>jar</packaging>
 
    <dependencies>
@@ -95,51 +95,26 @@
                </execution>
             </executions>
          </plugin>
-
+      
          <!-- skip unit test run, tests to be executed during integration-test -->
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
                <skip>true</skip>
-               
             </configuration>
          </plugin>
-         
-         <!--plugin>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-               <execution>
-                  <id>unpack-base-tests</id>
-                  <phase>process-test-classes</phase>
-                  <goals>
-                     <goal>unpack</goal>
-                  </goals>
-                  <configuration>
-                     <artifactItems>
-                        <artifactItem>
-                           <groupId>org.jboss.seam.solder</groupId>
-                           <artifactId>seam-solder-testsuite-integration-internals-base</artifactId>
-                           <version>${project.version}</version>
-                           <type>jar</type>
-                           <outputDirectory>${project.build.directory}/test-classes/</outputDirectory>
-                        </artifactItem>
-                     </artifactItems>
-                  </configuration>
-               </execution>
-            </executions>
-         </plugin-->
       </plugins>
    </build>
 
    <profiles>
       <profile>
-         <id>jbossas-managed-7</id>
+         <id>arquillian-weld-ee-embedded-1.1</id>
          <activation>
             <activeByDefault>true</activeByDefault>
             <property>
                <name>arquillian</name>
-               <value>jbossas-managed-7</value>
+               <value>arquillian-weld-ee-embedded-1.1</value>
             </property>
          </activation>
          
@@ -147,7 +122,7 @@
          
             <dependency>
                <groupId>org.jboss.seam.test</groupId>
-               <artifactId>jbossas-managed-7</artifactId>
+               <artifactId>weld-ee-embedded-1.1</artifactId>
                <type>pom</type>
                <scope>test</scope>
             </dependency>
@@ -156,33 +131,6 @@
          
          <build>
             <plugins>
-               <!-- Get AS and put into "target" -->
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-dependency-plugin</artifactId>
-                  <executions>
-                     <execution>
-                        <id>unpack-as7</id>
-                        <phase>process-test-classes</phase> <!-- So run before testing -->
-                        <goals>
-                           <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                           <artifactItems>
-                              <artifactItem>
-                                 <groupId>org.jboss.as</groupId>
-                                 <artifactId>jboss-as-dist</artifactId>
-                                 <version>${jbossas.7.version}</version>
-                                 <type>zip</type>
-                                 <overWrite>false</overWrite>
-                                 <outputDirectory>${project.build.directory}</outputDirectory>
-                              </artifactItem>
-                           </artifactItems>
-                        </configuration>
-                     </execution>
-                  </executions>
-               </plugin>
-               
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
@@ -202,7 +150,7 @@
                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
                            <trimStackTrace>false</trimStackTrace>
                            <printSummary>true</printSummary>
-                           <!-- forkMode>always</forkMode -->
+                           <!--forkMode>always</forkMode-->
                         </configuration>
                      </execution>
                   </executions>

--- a/testsuite/internals/weld-ee-embedded/src/test/resources/arquillian.xml
+++ b/testsuite/internals/weld-ee-embedded/src/test/resources/arquillian.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  JBoss, Home of Professional Open Source
+  Copyright 2010, Red Hat Middleware LLC, and individual contributors
+  by the @authors tag. See the copyright.txt in the distribution for a
+  full listing of individual contributors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+   <engine>
+      <property name="deploymentExportPath">target/</property>
+   </engine>
+</arquillian>


### PR DESCRIPTION
This patch depends on changes in parent (https://github.com/seam/parent/pull/3), so better not merge until parent is updated.

Other things to note:
1. the targetContainerAdapterClass hack which determines the type of container doesn't work, so I disable it, setting the isEmbedded = false, therefore, some tests fail on weld-embedded.(org.jboss.seam.solder.test.el.ElTest 
   org.jboss.seam.solder.test.resourceLoader.ResourceLoaderTest)
2. I removed the <forkMode>always</forkMode> for now, as it breaks the MavenArtifactResolver, as discussed on seam-dev ml.
3. the GenericBeanAlternativeTest and TypedMessageBundleInjectionTest are failing on AS7 and gf embedded. Those are the tests that I had to fix as they were wrongly importing resources. It is thus suspicious that they are still failing, so maybe I didn't fix them properly, although the generated archives appear to be correct now, so they may also be signs of genuine bugs... 
