### PR TITLE
Correcting example of the documentation of the @Requires annotation

### DIFF
--- a/docs/src/main/docbook/en-US/solder-programmingmodel.xml
+++ b/docs/src/main/docbook/en-US/solder-programmingmodel.xml
@@ -111,7 +111,7 @@ import org.jboss.seam.solder.core.Veto;</programlisting>
             For example:
          </para>
          
-         <programlisting role="JAVA">@Requires(EntityManager.class)
+         <programlisting role="JAVA">@Requires("javax.persistence.EntityManager")
 class EntityManagerProducer {
    
    @Produces


### PR DESCRIPTION
I find this annoying bug (http://seamframework.org/Community/WhatParameterShouldRequiresUseAndWhatShouldRequiresDo) in Solder reference guide and I tried to repair it.

I am not sure that I am doing it right. If my pull request is not the best way of dealing with such a bug, I would like to know if it is the case and the correct procedures :)
