### PR TITLE
SOLDER-48: Provide injectable system properties

### DIFF
--- a/api/src/main/java/org/jboss/seam/solder/core/System.java
+++ b/api/src/main/java/org/jboss/seam/solder/core/System.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.seam.solder.core;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * Qualifier annotation provided access to system property values.
+ *
+ * @author <a href="mailto:ssachtleben@gmail.com">Sebastian Sachtleben</a>
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Documented
+public @interface System {
+
+}
+

--- a/impl/src/main/java/org/jboss/seam/solder/system/SystemProperties.java
+++ b/impl/src/main/java/org/jboss/seam/solder/system/SystemProperties.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.seam.solder.system;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+
+import org.jboss.seam.solder.core.System;
+
+/**
+ * Access to map of system {@link Properties}.
+ * 
+ * @author <a href="mailto:ssachtleben@gmail.com">Sebastian Sachtleben</a>
+ */
+@Named("sysProp")
+public class SystemProperties implements Map<Object, Object>, Serializable {
+
+    private static final long serialVersionUID = -6998532426617911086L;
+
+    private Properties properties = java.lang.System.getProperties();
+
+    @Produces
+    @System
+    private Properties getSystemProperties() {
+        return properties;
+    }
+
+    @Override
+    public int size() {
+        return getSystemProperties().size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return getSystemProperties().isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(final Object key) {
+        return getSystemProperties().containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(final Object value) {
+        return getSystemProperties().containsValue(value);
+    }
+
+    @Override
+    public String get(final Object key) {
+        return getSystemProperties().getProperty(key.toString());
+    }
+
+    @Override
+    public Object put(final Object key, final Object value) {
+        return getSystemProperties().put(key, value);
+    }
+
+    @Override
+    public String remove(final Object key) {
+        return getSystemProperties().remove(key).toString();
+    }
+
+    @Override
+    public void putAll(final Map<? extends Object, ? extends Object> m) {
+        getSystemProperties().putAll(m);
+    }
+
+    @Override
+    public void clear() {
+        getSystemProperties().clear();
+    }
+
+    @Override
+    public Set<Object> keySet() {
+        return getSystemProperties().keySet();
+    }
+
+    @Override
+    public Collection<Object> values() {
+        return getSystemProperties().values();
+    }
+
+    @Override
+    public Set<java.util.Map.Entry<Object, Object>> entrySet() {
+        return getSystemProperties().entrySet();
+    }
+
+}

--- a/testsuite/common/src/main/java/org/jboss/seam/solder/test/system/SystemPropertiesTest.java
+++ b/testsuite/common/src/main/java/org/jboss/seam/solder/test/system/SystemPropertiesTest.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.seam.solder.test.system;
+
+import java.util.Properties;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.seam.solder.core.System;
+import org.jboss.seam.solder.system.SystemProperties;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class SystemPropertiesTest {
+
+    @Inject
+    @System
+    private Properties properties;
+
+    @Deployment(name = "SystemPropertiesTest")
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, "test.war").addClass(SystemPropertiesTest.class).addClass(System.class)
+                .addClass(SystemProperties.class)
+                .addAsManifestResource(new ByteArrayAsset(new byte[0]), ArchivePaths.create("beans.xml"));
+    }
+
+    @Test
+    public void testDefaultBean() {
+        Assert.assertNotNull(properties);
+    }
+
+}


### PR DESCRIPTION
Added implementation of injectable system properties:

@Inject @System Properties properties

Works and tested by Arquillian case.
# {sysProp['os.name']}

Works in facelets.
