### PR TITLE
import arquillianized config testsuite

### DIFF
--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/AbstractXMLTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/AbstractXMLTest.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Set;
+
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+public abstract class AbstractXMLTest {
+    
+    @Inject
+    BeanManager manager;
+    
+    public <T> T getReference(Class<T> clazz, Annotation... bindings) {
+        Set<Bean<?>> beans = manager.getBeans(clazz, bindings);
+        if (beans.isEmpty()) {
+            throw new RuntimeException("No bean found with class: " + clazz + " and bindings " + Arrays.toString(bindings));
+        } else if (beans.size() != 1) {
+            StringBuilder bs = new StringBuilder("[");
+            for (Annotation a : bindings) {
+                bs.append(a.toString() + ",");
+            }
+            bs.append("]");
+            throw new RuntimeException("More than one bean found with class: " + clazz + " and bindings " + bs);
+        }
+        Bean<?> bean = beans.iterator().next();
+        return (T) manager.getReference(bean, clazz, manager.createCreationalContext(bean));
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/BootstrapTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/BootstrapTest.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.solder.config.xml.bootstrap.XmlConfigExtension;
+import org.jboss.solder.config.xml.bootstrap.XmlDocumentProvider;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class BootstrapTest extends AbstractXMLTest {
+
+    @Deployment(name = "BootstrapTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(BootstrapTest.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsServiceProvider(XmlDocumentProvider.class, NullXmlProvider.class)
+            .addClass(NullXmlProvider.class);
+        }
+    
+    @Test
+    public void testDocumentProviders() {
+        XmlConfigExtension extension = getReference(XmlConfigExtension.class);
+        List<Class<? extends XmlDocumentProvider>> providers = extension.getDocumentProviders();
+        Assert.assertTrue("Expected to find two providers, got this instead: " + providers.toString(), providers.size() == 2);
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/NamespaceResolverTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/NamespaceResolverTest.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import junit.framework.Assert;
+import org.jboss.solder.config.xml.model.MethodXmlItem;
+import org.jboss.solder.config.xml.model.PropertyXmlItem;
+import org.jboss.solder.config.xml.model.XmlItem;
+import org.jboss.solder.config.xml.model.XmlItemType;
+import org.jboss.solder.config.xml.parser.SaxNode;
+import org.jboss.solder.config.xml.parser.namespace.CompositeNamespaceElementResolver;
+import org.jboss.solder.config.xml.parser.namespace.NamespaceElementResolver;
+import org.jboss.solder.config.xml.parser.namespace.PackageNamespaceElementResolver;
+import org.jboss.solder.config.xml.test.common.simple.Bean1;
+import org.junit.Test;
+
+public class NamespaceResolverTest {
+
+    @Test
+    public void testPackageResolver() {
+        PackageNamespaceElementResolver resolver = new PackageNamespaceElementResolver("org.jboss.solder.config.xml.test.common.simple");
+        testResolver(resolver);
+    }
+
+    @Test
+    public void testCompositePackageResolver() {
+        List<String> namespaces = new ArrayList<String>();
+        namespaces.add("java.lang");
+        namespaces.add("java.util");
+        namespaces.add("org.jboss.solder.config.xml.test.common.simple");
+        CompositeNamespaceElementResolver resolver = new CompositeNamespaceElementResolver(namespaces);
+        testResolver(resolver);
+    }
+
+    public void testResolver(NamespaceElementResolver resolver) {
+
+        XmlItem item = resolver.getItemForNamespace(new SaxNode("Bean1", null, null, null, null, 0), null);
+        Assert.assertTrue("Namespace resolver returned wrong class type", item.getJavaClass() == Bean1.class);
+        Assert.assertTrue("Namespace resolver did not return class", item.getType() == XmlItemType.CLASS);
+        XmlItem method = resolver.getItemForNamespace(new SaxNode("method1", null, null, null, null, 0), item);
+        Assert.assertTrue("Item returned wrong type", method.getType() == XmlItemType.METHOD);
+
+        method.resolveChildren(null);
+
+        Assert.assertTrue("Could not resolve method", ((MethodXmlItem) method).getMethod() != null);
+        Assert.assertTrue("Wrong method was resolved", ((MethodXmlItem) method).getMethod().getParameterTypes().length == 0);
+
+        XmlItem field = resolver.getItemForNamespace(new SaxNode("field1", null, null, null, null, 0), item);
+        Assert.assertTrue("Element of wrong type returned", ((PropertyXmlItem) field).getType() == XmlItemType.FIELD);
+        Assert.assertTrue("field was not set", ((PropertyXmlItem) field).getField() != null);
+
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/NullXmlProvider.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/NullXmlProvider.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common;
+
+import org.jboss.solder.config.xml.bootstrap.XmlDocument;
+import org.jboss.solder.config.xml.bootstrap.XmlDocumentProvider;
+
+public class NullXmlProvider implements XmlDocumentProvider {
+
+    public void close() {
+    }
+
+    public XmlDocument getNextDocument() {
+        return null;
+    }
+
+    public void open() {
+      
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/constructor/ConstructedBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/constructor/ConstructedBean.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.constructor;
+
+public class ConstructedBean {
+    public ConstructedBean(int val) {
+        this.value = val;
+    }
+
+    public ConstructedBean() {
+
+    }
+
+    int value;
+
+    public int getValue() {
+        return value;
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/constructor/ConstructorTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/constructor/ConstructorTest.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.constructor;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class ConstructorTest {    
+    @Deployment(name = "ConstructorTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(ConstructorTest.class, "constructor-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(ConstructedBean.class, ValueProvider.class);            
+    }
+    
+    @Inject
+    ConstructedBean bean;
+
+    @Test
+    public void testBeanConstructorAnnotations() {
+        Assert.assertTrue(bean.getValue() == 10);
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/constructor/ValueProvider.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/constructor/ValueProvider.java
@@ -1,0 +1,22 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.constructor;
+
+
+public class ValueProvider {
+    public int value;
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/ArrayFieldValue.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/ArrayFieldValue.java
@@ -1,0 +1,23 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+public class ArrayFieldValue {
+    public int[] iarray;
+    public Class<?>[] carray;
+    public String[] sarray;
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/CollectionFieldValue.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/CollectionFieldValue.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+public class CollectionFieldValue {
+    public Set<Integer> iset;
+    public SortedSet<String> sset;
+    public List<Class<?>> clist;
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/ELFieldValueBeanTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/ELFieldValueBeanTest.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import java.util.Map.Entry;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class ELFieldValueBeanTest {
+    
+    @Deployment(name = "ELFieldValueBeanTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(ELFieldValueBeanTest.class, "el-set-field-value-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(ELValueBean.class, ELValueProducer.class);
+    }
+    
+    @Inject
+    ELValueBean bean;
+
+    @Test
+    public void mapSetFieldValue() {
+        Assert.assertTrue(bean.array.length == 1);
+        Assert.assertEquals(bean.array[0], ELValueProducer.EL_VALUE_STRING);
+        Assert.assertTrue(bean.list.size() == 1);
+        Assert.assertEquals(bean.list.get(0), ELValueProducer.EL_VALUE_STRING);
+        Assert.assertTrue(bean.map.size() == 1);
+        Entry<String, String> entry = bean.map.entrySet().iterator().next();
+        Assert.assertEquals(entry.getKey(), ELValueProducer.EL_VALUE_STRING);
+        Assert.assertEquals(entry.getValue(), ELValueProducer.EL_VALUE_STRING);
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/ELValueBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/ELValueBean.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Bean that test values set via el in arrays, lists and maps
+ *
+ * @author stuart
+ */
+public class ELValueBean {
+    public List<String> list;
+    public Map<String, String> map;
+    public String[] array;
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/ELValueProducer.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/ELValueProducer.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+
+public class ELValueProducer {
+
+    public static final String EL_VALUE_STRING = "EL Value String";
+
+    @Produces
+    @Named("elValue")
+    public String getElValue() {
+        return EL_VALUE_STRING;
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/FieldValueBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/FieldValueBean.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import java.math.BigDecimal;
+
+import org.jboss.solder.config.xml.test.common.method.QualifierEnum;
+
+public class FieldValueBean {
+
+    public void init() {
+        assert ivalue != 20;
+    }
+
+    private int ivalue = 20;
+
+    public String stringValue;
+
+    public QualifierEnum enumValue;
+
+    public boolean bvalue;
+
+    public float fvalue = 1;
+
+    public double dvalue = 1;
+
+    private BigDecimal bigDecimalValue;
+
+    public BigDecimal readBigDecimalValue() {
+        return bigDecimalValue;
+    }
+
+    public short svalue;
+
+    public long lvalue;
+
+    public String elValue;
+
+    public String elInnerTextValue;
+
+    int noFieldValue;
+
+    public void setIvalue(int value) {
+        this.ivalue = value + 1;
+    }
+
+    public int getIvalue() {
+        return ivalue;
+    }
+
+    public int getNoField() {
+        return noFieldValue;
+    }
+
+    public void setNoField(int value) {
+        noFieldValue = value;
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/FieldValueProducer.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/FieldValueProducer.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+public class FieldValueProducer {
+    public String value;
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/FieldsetQualifier.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/FieldsetQualifier.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({TYPE, METHOD, PARAMETER, FIELD})
+@Qualifier
+public @interface FieldsetQualifier {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/Horse.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/Horse.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+public class Horse {
+    private HorseShoe shoe;
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public HorseShoe getShoe() {
+        return shoe;
+    }
+
+    public void setShoe(HorseShoe shoe) {
+        this.shoe = shoe;
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/HorseShoe.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/HorseShoe.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+public class HorseShoe {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/InlineBeanFieldValueBeanTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/InlineBeanFieldValueBeanTest.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.enterprise.inject.Default;
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class InlineBeanFieldValueBeanTest {
+    
+    @Deployment(name = "InlineBeanFieldValueBeanTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(InlineBeanFieldValueBeanTest.class, "inline-bean-field-value-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(Knight.class, Sword.class, Horse.class, HorseShoe.class);
+    }
+    
+    @Inject
+    @Default
+    Knight knight;
+
+    @Test
+    public void simpleInlineBeanTest() {
+        Assert.assertTrue(knight.getSword().getType().equals("sharp"));
+        Assert.assertTrue(knight.getHorse().getShoe() != null);
+        Assert.assertTrue(knight.getHorse().getName().equals("billy"));
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/Knight.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/Knight.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import org.jboss.solder.core.Veto;
+
+@Veto
+public class Knight {
+    Sword sword;
+
+    Horse horse;
+
+    public Sword getSword() {
+        return sword;
+    }
+
+    public void setSword(Sword sword) {
+        this.sword = sword;
+    }
+
+    public Horse getHorse() {
+        return horse;
+    }
+
+    public void setHorse(Horse horse) {
+        this.horse = horse;
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/MapFieldValue.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/MapFieldValue.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import java.util.Map;
+
+public class MapFieldValue {
+    public Map<Integer, String> map1;
+
+    public Map<String, Class<?>> map2;
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/PropertiesFieldValue.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/PropertiesFieldValue.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import java.util.Properties;
+
+public class PropertiesFieldValue {
+
+    public Properties properties1;
+
+    public Properties properties2;
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/SetArrayFieldValueBeanTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/SetArrayFieldValueBeanTest.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class SetArrayFieldValueBeanTest {
+    
+    @Deployment(name = "SetArrayFieldValueBeanTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(SetArrayFieldValueBeanTest.class, "array-set-field-value-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(ArrayFieldValue.class);
+    }
+
+    @Inject
+    ArrayFieldValue x;
+    
+    @Test
+    public void arrayFieldSetterTest() {
+        Assert.assertTrue(x.carray.length == 2);
+        Assert.assertTrue(x.iarray.length == 2);
+        Assert.assertTrue(x.sarray.length == 2);
+        Assert.assertTrue(x.sarray[0].equals("hello"));
+        Assert.assertTrue(x.sarray[1].equals("world"));
+        Assert.assertTrue(x.iarray[0] == 1);
+        Assert.assertTrue(x.iarray[1] == 2);
+        Assert.assertTrue(x.carray[0] == Integer.class);
+        Assert.assertTrue(x.carray[1] == Long.class);
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/SetCollectionFieldValueBeanTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/SetCollectionFieldValueBeanTest.java
@@ -1,0 +1,74 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class SetCollectionFieldValueBeanTest {
+    
+    @Deployment(name = "SetCollectionFieldValueBeanTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(SetCollectionFieldValueBeanTest.class, "colection-set-field-value-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(CollectionFieldValue.class);
+    }
+    
+    @Inject
+    CollectionFieldValue x;
+
+    @Test
+    public void collectionSetFieldValue() {
+        Assert.assertTrue(x.iset.size() == 2);
+        Assert.assertTrue(x.clist.size() == 2);
+        Assert.assertTrue(x.sset.size() == 2);
+        boolean first = true;
+        for (String i : x.sset) {
+            if (first) {
+                Assert.assertTrue(i.equals("1"));
+                first = false;
+            } else {
+                Assert.assertTrue(i.equals("2"));
+            }
+
+        }
+        first = true;
+        for (Integer i : x.iset) {
+            if (first) {
+                Assert.assertTrue(i.equals(new Integer(1)));
+                first = false;
+            } else {
+                Assert.assertTrue(i.equals(new Integer(2)));
+            }
+
+        }
+        Assert.assertTrue(x.clist.get(0) == Integer.class);
+        Assert.assertTrue(x.clist.get(1) == Long.class);
+
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/SetFieldValueBeanTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/SetFieldValueBeanTest.java
@@ -1,0 +1,79 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import java.math.BigDecimal;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.solder.config.xml.test.common.method.QualifierEnum;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class SetFieldValueBeanTest {
+    
+    @Deployment(name = "SetFieldValueBeanTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(SetFieldValueBeanTest.class, "set-field-value-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(FieldValueBean.class, FieldsetQualifier.class, ELValueProducer.class, QualifierEnum.class);
+    }
+    
+    @Inject FieldValueBean x;
+
+    @Test
+    public void simpleFieldSetterTest() {
+        Assert.assertTrue(x.readBigDecimalValue().compareTo(BigDecimal.TEN) == 0);
+        Assert.assertTrue(x.bvalue == true);
+        Assert.assertTrue(x.dvalue == 0);
+        Assert.assertTrue(x.enumValue == QualifierEnum.A);
+        Assert.assertTrue(x.fvalue == 0);
+        Assert.assertTrue(x.getIvalue() == 11);
+        Assert.assertTrue(x.lvalue == 23);
+        Assert.assertTrue(x.svalue == 4);
+        Assert.assertTrue(x.noFieldValue == 7);
+        Assert.assertEquals(ELValueProducer.EL_VALUE_STRING, x.elValue);
+        Assert.assertEquals(ELValueProducer.EL_VALUE_STRING, x.elInnerTextValue);
+    }
+    
+    @Inject
+    @FieldsetQualifier
+    FieldValueBean y;
+
+    @Test
+    public void simpleShorthandFieldSetterTest() {
+        Assert.assertTrue(y.readBigDecimalValue().compareTo(BigDecimal.TEN) == 0);
+        Assert.assertTrue(y.bvalue == true);
+        Assert.assertTrue(y.dvalue == 0);
+        Assert.assertTrue(y.enumValue == QualifierEnum.A);
+        Assert.assertTrue(y.fvalue == 0);
+        Assert.assertTrue(y.getIvalue() == 11);
+        Assert.assertTrue(y.lvalue == 23);
+        Assert.assertTrue(y.svalue == 4);
+        Assert.assertTrue(y.noFieldValue == 7);
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/SetMapFieldValueBeanTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/SetMapFieldValueBeanTest.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class SetMapFieldValueBeanTest {
+    
+    @Deployment(name = "SetMapFieldValueBeanTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(SetMapFieldValueBeanTest.class, "map-set-field-value-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(MapFieldValue.class);
+    }
+    
+    @Inject
+    MapFieldValue x;
+
+    @Test
+    public void mapSetFieldValue() {
+        Assert.assertTrue(x.map1.size() == 2);
+        Assert.assertTrue(x.map2.size() == 2);
+
+        Assert.assertTrue(x.map1.get(1).equals("hello"));
+        Assert.assertTrue(x.map1.get(2).equals("world"));
+        Assert.assertTrue(x.map2.get("1") == Integer.class);
+        Assert.assertTrue(x.map2.get("2") == Long.class);
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/SetPropertiesFieldValueBeanTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/SetPropertiesFieldValueBeanTest.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class SetPropertiesFieldValueBeanTest {
+
+    @Deployment(name = "SetPropertiesFieldValueBeanTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(SetPropertiesFieldValueBeanTest.class, "properties-set-field-value-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(PropertiesFieldValue.class);
+    }
+
+    @Inject
+    PropertiesFieldValue x;
+    
+    @Test
+    public void propertiesSetFieldValue() {
+        Assert.assertTrue(x.properties1.size() == 2);
+        Assert.assertTrue(x.properties2.size() == 2);
+
+        Assert.assertTrue(x.properties1.get("1").equals("hello"));
+        Assert.assertTrue(x.properties1.get("2").equals("world"));
+        Assert.assertTrue(x.properties2.get("key1").equals("Value 1"));
+        Assert.assertTrue(x.properties2.get("key2").equals("Value 2"));
+
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/Sword.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/fieldset/Sword.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.fieldset;
+
+public class Sword {
+    String type;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/OtherQualifier.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/OtherQualifier.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.injection;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jboss.solder.config.xml.test.common.method.QualifierEnum;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({TYPE, METHOD, PARAMETER, FIELD})
+public @interface OtherQualifier {
+    String value1();
+
+    int value2();
+
+    QualifierEnum value();
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/ProducerBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/ProducerBean.java
@@ -1,0 +1,22 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.injection;
+
+public class ProducerBean {
+    public String value;
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/ProducerFieldValueBeanTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/ProducerFieldValueBeanTest.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.injection;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class ProducerFieldValueBeanTest {
+    
+    @Deployment(name = "ProducerFieldValueBeanTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(ProducerFieldValueBeanTest.class, "producer-field-value-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(RecieverBean.class, ProducerBean.class, ProducerQualifier.class);
+    }
+    
+    @Inject
+    RecieverBean s;
+
+    @Test
+    public void testProducerField() {
+        Assert.assertTrue(s.value.equals("hello world"));
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/ProducerQualifier.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/ProducerQualifier.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.injection;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({TYPE, METHOD, PARAMETER, FIELD})
+public @interface ProducerQualifier {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/QualifiedBean1.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/QualifiedBean1.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.injection;
+
+import org.jboss.solder.config.xml.test.common.method.QualifiedType;
+
+public class QualifiedBean1 implements QualifiedType {
+
+    public int getBeanNumber() {
+        return 1;
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/QualifiedBean2.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/QualifiedBean2.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.injection;
+
+import org.jboss.solder.config.xml.test.common.method.QualifiedType;
+
+public class QualifiedBean2 implements QualifiedType {
+
+    public int getBeanNumber() {
+        return 2;
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/QualifierAttributesTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/QualifierAttributesTest.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.injection;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.solder.config.xml.test.common.method.QualifiedType;
+import org.jboss.solder.config.xml.test.common.method.QualifierEnum;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test that XML configured Qualifiers work as expected
+ */
+@RunWith(Arquillian.class)
+public class QualifierAttributesTest {
+    
+    @Deployment(name = "QualifierAttributesTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(QualifierAttributesTest.class, "qualifier-attributes-test-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(QualifierTestBean.class, QualifiedType.class, QualifiedBean1.class, QualifiedBean2.class, 
+                    OtherQualifier.class, QualifierEnum.class);
+    }
+    
+    @Inject
+    QualifierTestBean x;
+
+    @Test()
+    public void testQualifiersWithAttributes() {
+        Assert.assertTrue(x.bean1.getBeanNumber() == 1);
+        Assert.assertTrue(x.bean2.getBeanNumber() == 2);
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/QualifierTestBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/QualifierTestBean.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.injection;
+
+import org.jboss.solder.config.xml.test.common.method.QualifiedType;
+
+public class QualifierTestBean {
+
+    public QualifiedType bean1;
+
+    public QualifiedType bean2;
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/RecieverBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/injection/RecieverBean.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.injection;
+
+public class RecieverBean {
+    public String value;
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/interceptor/Binding.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/interceptor/Binding.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.interceptor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface Binding {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/interceptor/InterceptedBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/interceptor/InterceptedBean.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.interceptor;
+
+@Binding
+public class InterceptedBean {
+
+    public String method() {
+        return "hello";
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/interceptor/InterceptorBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/interceptor/InterceptorBean.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.interceptor;
+
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.InvocationContext;
+
+public class InterceptorBean {
+    @AroundInvoke
+    public Object myMethod(InvocationContext context) throws Exception {
+        return context.proceed().toString() + " world";
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/interceptor/InterceptorTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/interceptor/InterceptorTest.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.interceptor;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class InterceptorTest {
+    
+    @Deployment(name = "InterceptorTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(InterceptorTest.class, "interceptor-beans.xml")
+            .addAsWebInfResource("META-INF/config-beans.xml", "beans.xml")
+            .addClasses(InterceptedBean.class, InterceptorBean.class, Binding.class);
+    }
+    
+    @Inject
+    InterceptedBean x;
+
+    @Test
+    public void testInterceptors() {
+
+        String res = x.method();
+        Assert.assertEquals("hello world", res);
+
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/DecoratedInterface.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/DecoratedInterface.java
@@ -1,0 +1,20 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+public interface DecoratedInterface {
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/Decorator1.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/Decorator1.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+public class Decorator1 {
+
+    DecoratedInterface decoratedObject;
+
+    public void a() {
+
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/MethodBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/MethodBean.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+import javax.enterprise.inject.Instance;
+
+public class MethodBean {
+
+    public int method() {
+        return 1;
+    }
+
+    public int method(MethodValueBean bean) {
+        return bean.value + 1;
+    }
+
+    public long method(MethodValueBean[][] beans) {
+        return beans.length;
+    }
+
+    public int method(Instance<MethodValueBean> bean) {
+        return bean.get().getValue() + 1;
+    }
+
+    public int method(Instance<MethodValueBean> bean, Instance<MethodValueBean> bean1) {
+        return bean.get().getValue() + 1;
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/MethodTarget.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/MethodTarget.java
@@ -1,0 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+public class MethodTarget {
+
+    public int value1, value2, value3;
+
+    public long longValue;
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/MethodTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/MethodTest.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class MethodTest {
+    
+    @Deployment(name = "MethodTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(MethodTest.class, "method-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(MethodTarget.class,
+                Qualifier1.class, Qualifier2.class, Qualifier3.class,
+                MethodBean.class, MethodValueBean.class, MethodValueArrayProducer.class);
+    }
+    
+    @Inject
+    MethodTarget x;
+
+    @Test
+    public void methodTest() {
+        assert x != null;
+        assert x.value1 == 1;
+        assert x.value2 == 11;
+        assert x.value3 == 11;
+        assert x.longValue == 10;
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/MethodValueArrayProducer.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/MethodValueArrayProducer.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+import javax.enterprise.inject.Produces;
+
+public class MethodValueArrayProducer {
+    @Produces
+    @Qualifier2
+    public MethodValueBean[][] createMethodValueBeans() {
+        return new MethodValueBean[10][10];
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/MethodValueBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/MethodValueBean.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+public class MethodValueBean {
+    public int value = 10;
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/PrimitiveBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/PrimitiveBean.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+public class PrimitiveBean {
+    public int add(int val) {
+        return val + 1;
+    }
+
+    public int[] add(int[] val) {
+        for (int i = 0; i < val.length; ++i) {
+            val[i] = val[i] + 1;
+        }
+        return val;
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/PrimitiveMethodTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/PrimitiveMethodTest.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class PrimitiveMethodTest {
+    
+    @Deployment(name = "PrimitiveMethodTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(PrimitiveMethodTest.class, "primitive-method-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(Qualifier1.class, Qualifier2.class, PrimitiveBean.class, PrimitiveValueProducer.class);
+    }
+    
+    @Inject
+    @Qualifier1
+    int x;
+    
+    @Inject
+    @Qualifier2
+    int[] y;
+
+    @Test
+    public void methodTest() {
+        Assert.assertTrue(x == 1);
+        for (int i = 0; i < y.length; ++i) {
+            Assert.assertTrue(y[i] == i + 2);
+        }
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/PrimitiveValueProducer.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/PrimitiveValueProducer.java
@@ -1,0 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+public class PrimitiveValueProducer {
+    public int value = 0;
+
+    public int[] value2 = {1, 2, 3};
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/QualifiedType.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/QualifiedType.java
@@ -1,0 +1,22 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+public interface QualifiedType {
+    public int getBeanNumber();
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/Qualifier1.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/Qualifier1.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Qualifier1 {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/Qualifier2.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/Qualifier2.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Qualifier2 {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/Qualifier3.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/Qualifier3.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Qualifier3 {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/QualifierEnum.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/method/QualifierEnum.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.method;
+
+public enum QualifierEnum {
+    A, B, C;
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/producer/MultipleProducerBeanTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/producer/MultipleProducerBeanTest.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.producer;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class MultipleProducerBeanTest {
+    
+    @Deployment(name = "MultipleProducerBeanTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(MultipleProducerBeanTest.class, "multiple-producers.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(Reciever.class, Producer.class, ProducerQualifier.class);
+    }
+
+    @Inject
+    Reciever s;
+    
+    @Test
+    public void testProducerField() {
+
+        Assert.assertTrue(s.val1 == 1);
+        Assert.assertTrue(s.val2 == 2);
+    }
+
+    @Test
+    public void testProducerMethod() {
+
+        Assert.assertTrue(s.meth1 == 1);
+        Assert.assertTrue(s.meth2 == 2);
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/producer/Producer.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/producer/Producer.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.producer;
+
+public class Producer {
+    public int value;
+
+    public int meth() {
+        return value;
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/producer/ProducerQualifier.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/producer/ProducerQualifier.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.producer;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Qualifier;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+public @interface ProducerQualifier {
+    int value();
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/producer/Reciever.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/producer/Reciever.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.producer;
+
+
+public class Reciever {
+    public int val1;
+
+    public int val2;
+
+    public int meth1;
+
+    public int meth2;
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/Bean1.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/Bean1.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.simple;
+
+public class Bean1 {
+
+    public int value = 0;
+
+    public void method1() {
+
+    }
+
+    public void method1(String param) {
+
+    }
+
+    public String field1 = "aa";
+
+    public Bean2 bean2;
+
+    public void pcMethod() {
+        value = 1;
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/Bean2.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/Bean2.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.simple;
+
+import java.util.Set;
+
+public class Bean2 {
+    public void method1() {
+
+    }
+
+    public String[] arrayField;
+
+    public int intField;
+    public String stringField;
+
+    public Set<String> setField;
+
+    public Bean3 produceBean3() {
+        return new Bean3();
+    }
+
+    public String produceBean3;
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/Bean3.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/Bean3.java
@@ -1,0 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.simple;
+
+import org.jboss.solder.core.Veto;
+
+@Veto
+public class Bean3 {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/EmptyRootNamespaceTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/EmptyRootNamespaceTest.java
@@ -1,0 +1,29 @@
+package org.jboss.solder.config.xml.test.common.simple;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.runner.RunWith;
+
+
+/**
+ * This test verifies that a no-namespace root element does not break the deployment.
+ *
+ * @author <a href="http://community.jboss.org/people/jharting">Jozef Hartinger</a>
+ * @see https://issues.jboss.org/browse/SEAMXML-45
+ */
+@RunWith(Arquillian.class)
+public class EmptyRootNamespaceTest extends SimpleBeanTest {
+    @Deployment(name = "EmptyRootNamespaceTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(EmptyRootNamespaceTest.class, "empty-root-namespace-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(SimpleBeanTest.class, 
+                    Bean1.class, Bean2.class, Bean3.class, 
+                    ExtendedBean.class, ExtendedQualifier1.class, ExtendedQualifier2.class,
+                    OverriddenBean.class, ScopeOverrideBean.class);
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/ExtendedBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/ExtendedBean.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.simple;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ExtendedQualifier1
+@ApplicationScoped
+public class ExtendedBean {
+    public List<String> getData() {
+        return null;
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/ExtendedQualifier1.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/ExtendedQualifier1.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.simple;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Qualifier;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+public @interface ExtendedQualifier1 {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/ExtendedQualifier2.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/ExtendedQualifier2.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.simple;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Qualifier;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+public @interface ExtendedQualifier2 {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/OverriddenBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/OverriddenBean.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.simple;
+
+public class OverriddenBean {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/ScopeOverrideBean.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/ScopeOverrideBean.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.simple;
+
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public class ScopeOverrideBean {
+    public ScopeOverrideBean() {
+        value = 1;
+    }
+
+    private int value;
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/ScopeOverrideTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/ScopeOverrideTest.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.simple;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.solder.config.xml.test.common.AbstractXMLTest;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class ScopeOverrideTest extends AbstractXMLTest {
+    
+    @Deployment(name = "ScopeOverrideTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(ScopeOverrideTest.class, "simple-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(Bean1.class, Bean2.class, Bean3.class, 
+                    ExtendedBean.class, ExtendedQualifier1.class, ExtendedQualifier2.class,
+                    OverriddenBean.class, ScopeOverrideBean.class);
+    }
+
+    @Test
+    public void scopeOverrideTest() {       
+        ScopeOverrideBean x = getReference(ScopeOverrideBean.class);
+        x.setValue(10);
+        x = getReference(ScopeOverrideBean.class);
+        Assert.assertEquals(10, x.getValue());
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/SimpleBeanTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/simple/SimpleBeanTest.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.simple;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Unit test for simple App.
+ */
+@RunWith(Arquillian.class)
+public class SimpleBeanTest {
+    
+    @Deployment(name = "SimpleBeanTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(SimpleBeanTest.class, "simple-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(Bean1.class, Bean2.class, Bean3.class, 
+                ExtendedBean.class, ExtendedQualifier1.class, ExtendedQualifier2.class,
+                OverriddenBean.class, ScopeOverrideBean.class);
+    }
+    
+    @Inject
+    Bean1 x;
+    
+    @Inject
+    Bean2 bean2;
+    
+    @Inject
+    Bean3 y;
+
+    @Test
+    public void simpleBeanTest() {
+        Assert.assertTrue(x != null);
+        Assert.assertTrue(x.bean2 != null);
+
+        Assert.assertEquals("test value", bean2.produceBean3);
+
+        Assert.assertTrue(y != null);
+        Assert.assertTrue("Post construct method not called", x.value == 1);
+    }
+
+    @Inject
+    BeanManager manager;
+    
+    @Test
+    public void testOverride() {
+        Set<Bean<?>> beans = manager.getBeans(OverriddenBean.class);
+        Assert.assertTrue(beans.size() == 1);
+        Assert.assertTrue(beans.iterator().next().getName().equals("someBean"));
+
+    }
+    
+    @Inject
+    @ExtendedQualifier1
+    @ExtendedQualifier2
+    ExtendedBean ext;
+
+    @Test
+    public void testExtends() throws SecurityException, NoSuchMethodException {       
+        Assert.assertTrue(ext != null);
+        Method method = ext.getClass().getDeclaredMethod("getData");
+        method.getGenericReturnType();
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/stereotype/Stereotype1.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/stereotype/Stereotype1.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Stereotype1 {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/stereotype/StereotypeTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/stereotype/StereotypeTest.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.stereotype;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.solder.config.xml.test.common.interceptor.Binding;
+import org.jboss.solder.config.xml.test.common.interceptor.InterceptedBean;
+import org.jboss.solder.config.xml.test.common.interceptor.InterceptorBean;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * this is the same as the interceptor test except the interceptor is applied
+ * through a stereotype
+ */
+@RunWith(Arquillian.class)
+public class StereotypeTest {
+    
+    @Deployment(name = "StereotypeTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(StereotypeTest.class, "stereotype-beans.xml")
+            .addAsWebInfResource("META-INF/config-beans.xml", "beans.xml")
+            .addClasses(InterceptedBean.class, InterceptorBean.class, Binding.class,
+                    Stereotype1.class);
+    }
+    
+    @Inject
+    InterceptedBean x;
+
+    @Test
+    public void testStereotypes() {
+
+        String res = x.method();
+        Assert.assertEquals("hello world", res);
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/types/AllowedType.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/types/AllowedType.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.types;
+
+public class AllowedType implements SomeInterface {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/types/RestrictedType.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/types/RestrictedType.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.types;
+
+public class RestrictedType implements SomeInterface {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/types/SomeInterface.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/types/SomeInterface.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.types;
+
+public interface SomeInterface {
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/types/TypeInjectedClass.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/types/TypeInjectedClass.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.types;
+
+
+public class TypeInjectedClass {
+    SomeInterface createValue;
+
+    public void create(SomeInterface value) {
+        this.createValue = value;
+    }
+
+    public SomeInterface value;
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/types/TypesTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/types/TypesTest.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.types;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * tests that <types> restricts the allowed types of an injection point
+ */
+@RunWith(Arquillian.class)
+public class TypesTest {
+    
+    @Deployment(name = "TypesTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(TypesTest.class, "types-test-beans.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(TypeInjectedClass.class, SomeInterface.class, AllowedType.class, RestrictedType.class);
+    }
+    
+    @Inject
+    TypeInjectedClass x;
+
+    @Test
+    public void testTypeRestriction() {
+        Assert.assertTrue(x.value instanceof AllowedType);
+        Assert.assertTrue(x.createValue instanceof RestrictedType);
+
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/util/Deployments.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/util/Deployments.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.util;
+
+import java.io.File;
+
+import org.jboss.solder.config.xml.test.common.AbstractXMLTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+public class Deployments {
+
+    private static final String SOLDER_API_JAR = "../api/target/solder-api.jar";
+    private static final String SOLDER_IMPL_JAR = "../impl/target/solder-impl.jar";
+    private static final String SOLDER_LOGGING_JAR = "../logging/target/solder-logging.jar";
+
+    public static WebArchive baseDeployment(Class<?> klass) {
+        return ShrinkWrap.create(WebArchive.class, "test.war")
+                .addAsLibraries(
+                ShrinkWrap.create(
+                    ZipImporter.class, "solder-api.jar")
+                        .importFrom(new File(SOLDER_API_JAR))
+                        .as(JavaArchive.class),
+                ShrinkWrap.create(
+                    ZipImporter.class, "solder-impl.jar")
+                        .importFrom(new File(SOLDER_IMPL_JAR))
+                        .as(JavaArchive.class),
+                ShrinkWrap.create(
+                    ZipImporter.class, "solder-logging.jar")
+                        .importFrom(new File(SOLDER_LOGGING_JAR))
+                        .as(JavaArchive.class))
+                .addClass(AbstractXMLTest.class)
+                .addClass(klass);
+        }
+
+    public static WebArchive baseDeployment(Class<?> klass, String xmlFileName) {
+
+        String fileName = klass.getPackage().getName().replace('.', '/') + "/" + xmlFileName;
+
+        WebArchive archive = baseDeployment(klass)
+        // weld-embedded reads it from META-INF/seam-beans.xml, not from WEB-INF/classes/META-INF/seam-beans.xml as it should
+        // so we add it to both locations
+        .addAsResource(fileName, "META-INF/seam-beans.xml").addAsManifestResource(fileName, "seam-beans.xml");
+
+        return archive;
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/util/MavenArtifactResolver.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/util/MavenArtifactResolver.java
@@ -1,0 +1,152 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.util;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Resolves a maven artifact present on the test classpath.
+ *
+ * @author Stuart Douglas
+ */
+public class MavenArtifactResolver {
+
+    public static File resolve(String groupId, String artifactId) {
+        if (groupId == null) {
+            throw new IllegalArgumentException("groupId cannot be null");
+        }
+        if (artifactId == null) {
+            throw new IllegalArgumentException("artifactId cannot be null");
+        }
+        String path = new MavenArtifactResolver(groupId.trim(), artifactId.trim(), System.getProperty("java.class.path"), File.pathSeparatorChar, File.separatorChar).resolve();
+        if (path == null) {
+            throw new IllegalArgumentException("Cannot locate artifact for " + groupId + ":" + artifactId);
+        }
+        return new File(path);
+    }
+
+    public static File resolve(String qualifiedArtifactId) {
+        String[] segments = qualifiedArtifactId.split(":");
+        if (segments.length == 2) {
+            return resolve(segments[0], segments[1]);
+        } else {
+            throw new IllegalArgumentException("Unable to parse " + qualifiedArtifactId + " as a groupId:artifactId");
+        }
+    }
+
+    private final String versionRegex;
+    private final String classPathSeparatorRegex;
+    private final char fileSeparator;
+    private final String groupId;
+    private final String artifactId;
+    private final String classPath;
+
+    MavenArtifactResolver(String groupId, String artifactId, String classPath, char pathSeparator, char fileSeparator) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.classPath = classPath;
+        this.classPathSeparatorRegex = "[^" + pathSeparator + "]*";
+        this.fileSeparator = fileSeparator;
+        
+        // Hack, Needed to prevent matching jars with common prefix
+        this.versionRegex = "-[0-9]";
+    }
+
+    String resolve() {
+        Matcher matches = createFullyQualifiedMatcher();
+        if (!matches.find()) {
+            matches = createUnqualifiedMatcher();
+            if (!matches.find()) {
+                matches = createTargetClassesMatcher();
+                if (!matches.find()) {
+                    return null;
+                } else {
+                    String fileName = scanForArtifact(matches);
+                    if (fileName == null) {
+                        return null;
+                    } else {
+                        return fileName;
+                    }
+                }
+            }
+        }
+        return matches.group(0);
+    }
+
+    private String scanForArtifact(Matcher targetClassesMatcher) {
+        // Locate all target/classes in classpath and store the path to all files target/
+        List<String> paths = new ArrayList<String>();
+        do {
+            String path = targetClassesMatcher.group();
+            File target = new File(path.substring(0, path.length() - 8));
+            if (target.exists()) {
+                if (!target.isDirectory()) {
+                    throw new IllegalStateException("Found ${project.dir}/target/ but it is not a directory!");
+                }
+                for (File file : target.listFiles()) {
+                    paths.add(file.getPath());
+                }
+            }
+        }
+        while (targetClassesMatcher.find());
+        return scanForArtifact(paths);
+    }
+
+    String scanForArtifact(List<String> paths) {
+        Pattern pattern = Pattern.compile(artifactId + "-[\\d+\\.]+(?:[\\-\\.]\\p{Alnum}*)?.jar$");
+        for (String path : paths) {
+            if (pattern.matcher(path).find()) {
+                return path;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Creates a matcher that returns any fully qualified matches of the form
+     * <code>com/acme/acme-core/1.0/acme-core-1.0.jar</code>. This will match
+     * artifacts on the classpath from the Maven repo.
+     */
+    private Matcher createFullyQualifiedMatcher() {
+        String pathString = groupId.replace('.', fileSeparator) + fileSeparator + artifactId + fileSeparator;
+        Pattern p = Pattern.compile(classPathSeparatorRegex + Pattern.quote(pathString) + classPathSeparatorRegex, Pattern.CASE_INSENSITIVE);
+        return p.matcher(classPath);
+    }
+
+    /**
+     * Creates a matcher that returns any unqualified matches of the form
+     * <code>target/acme-foo-1.0.jar</code>. This will match artifacts on the
+     * classpath from the reactor.
+     */
+    private Matcher createUnqualifiedMatcher() {
+        Pattern p = Pattern.compile(classPathSeparatorRegex + Pattern.quote("target" + fileSeparator + artifactId) + versionRegex + classPathSeparatorRegex, Pattern.CASE_INSENSITIVE);
+        return p.matcher(classPath);
+    }
+
+    /**
+     * Creates a matcher that returns any unqualified matches of the form
+     * <code>target/acme-foo-1.0.jar</code>. This locates all
+     */
+    private Matcher createTargetClassesMatcher() {
+        Pattern p = Pattern.compile(classPathSeparatorRegex + Pattern.quote("target" + fileSeparator + "classes") + classPathSeparatorRegex, Pattern.CASE_INSENSITIVE);
+        return p.matcher(classPath);
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/virtualproducer/VirtualProducerFieldTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/virtualproducer/VirtualProducerFieldTest.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.virtualproducer;
+
+import static org.jboss.solder.config.xml.test.common.util.Deployments.baseDeployment;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class VirtualProducerFieldTest {
+    
+    @Deployment(name = "VirtualProducerFieldTest")
+    public static Archive<?> deployment() {
+        return baseDeployment(VirtualProducerFieldTest.class, "virtualproducer.xml")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addClasses(VirtualProducerQualifier.class);
+    }
+    
+    @Inject
+    @VirtualProducerQualifier
+    String value;
+
+    @Test
+    public void testSimpleVirtualProducerField() {       
+        Assert.assertEquals("Hello World", value);
+    }
+}

--- a/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/virtualproducer/VirtualProducerQualifier.java
+++ b/testsuite/src/test/java/org/jboss/solder/config/xml/test/common/virtualproducer/VirtualProducerQualifier.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.config.xml.test.common.virtualproducer;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+@Qualifier
+public @interface VirtualProducerQualifier {
+
+}

--- a/testsuite/src/test/resources/META-INF/config-beans.xml
+++ b/testsuite/src/test/resources/META-INF/config-beans.xml
@@ -1,0 +1,10 @@
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:s="urn:java:ee"
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://docs.jboss.org/cdi/beans_1_0.xsd">
+
+    <interceptors>
+        <class>org.jboss.solder.config.xml.test.common.interceptor.InterceptorBean</class>
+    </interceptors>   
+
+</beans>

--- a/testsuite/src/test/resources/META-INF/services/org.jboss.solder.config.xml.bootstrap.XmlDocumentProvider
+++ b/testsuite/src/test/resources/META-INF/services/org.jboss.solder.config.xml.bootstrap.XmlDocumentProvider
@@ -1,0 +1,1 @@
+org.jboss.solder.config.xml.test.common.NullXmlProvider

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/constructor/constructor-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/constructor/constructor-beans.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.constructor">
+
+    <test:ValueProvider>
+        <test:value>
+            <Produces/>
+            <value>10</value>
+        </test:value>
+    </test:ValueProvider>
+
+    <test:ConstructedBean>
+        <replaces/>
+        <parameters>
+            <int/>
+        </parameters>
+    </test:ConstructedBean>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/array-set-field-value-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/array-set-field-value-beans.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.fieldset">
+    <test:ArrayFieldValue>
+        <replaces/>
+        <test:iarray>
+            <value>1</value>
+            <value>2</value>
+        </test:iarray>
+        <test:carray>
+            <value>java.lang.Integer</value>
+            <value>java.lang.Long</value>
+        </test:carray>
+        <test:sarray>
+            <value>hello</value>
+            <value>world</value>
+        </test:sarray>
+    </test:ArrayFieldValue>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/colection-set-field-value-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/colection-set-field-value-beans.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.fieldset">
+
+    <test:CollectionFieldValue>
+        <replaces/>
+        <test:iset>
+            <value>1</value>
+            <value>2</value>
+        </test:iset>
+        <test:clist>
+            <value>java.lang.Integer</value>
+            <value>java.lang.Long</value>
+        </test:clist>
+        <test:sset>
+            <value>2</value>
+            <value>1</value>
+        </test:sset>
+    </test:CollectionFieldValue>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/el-set-field-value-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/el-set-field-value-beans.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.fieldset">
+    <test:ELValueBean>
+        <replaces/>
+        <test:array>
+            <value>#{elValue}</value>
+        </test:array>
+        <test:list>
+            <value>#{elValue}</value>
+        </test:list>
+        <test:map>
+            <entry>
+                <key>#{elValue}</key>
+                <value>#{elValue}</value>
+            </entry>
+        </test:map>
+    </test:ELValueBean>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/inline-bean-field-value-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/inline-bean-field-value-beans.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.fieldset">
+
+    <test:Knight>
+
+        <test:sword>
+            <value>
+                <test:Sword type="sharp"/>
+            </value>
+        </test:sword>
+
+        <test:horse>
+            <value>
+                <test:Horse>
+                    <test:name>
+                        <value>billy</value>
+                    </test:name>
+                    <test:shoe>
+                        <Inject/>
+                    </test:shoe>
+                </test:Horse>
+            </value>
+        </test:horse>
+
+    </test:Knight>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/map-set-field-value-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/map-set-field-value-beans.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.fieldset">
+    <test:MapFieldValue>
+        <replaces/>
+        <test:map1>
+            <entry>
+                <key>1</key>
+                <value>hello</value>
+            </entry>
+            <entry>
+                <key>2</key>
+                <value>world</value>
+            </entry>
+        </test:map1>
+        <test:map2>
+            <e>
+                <k>1</k>
+                <v>java.lang.Integer</v>
+            </e>
+            <e>
+                <k>2</k>
+                <v>java.lang.Long</v>
+            </e>
+        </test:map2>
+
+    </test:MapFieldValue>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/properties-set-field-value-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/properties-set-field-value-beans.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.fieldset">
+    <test:PropertiesFieldValue>
+        <replaces/>
+        <test:properties1>
+            <entry>
+                <key>1</key>
+                <value>hello</value>
+            </entry>
+            <entry>
+                <key>2</key>
+                <value>world</value>
+            </entry>
+        </test:properties1>
+        <test:properties2>
+            <e>
+                <k>key1</k>
+                <v>Value 1</v>
+            </e>
+            <e>
+                <k>key2</k>
+                <v>Value 2</v>
+            </e>
+        </test:properties2>
+
+    </test:PropertiesFieldValue>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/set-field-value-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/fieldset/set-field-value-beans.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.fieldset">
+
+    <test:FieldValueBean>
+        <replaces/>
+        <test:init>
+            <Inject/>
+        </test:init>
+        <test:ivalue>10</test:ivalue>
+        <test:stringValue>hello world</test:stringValue>
+        <test:enumValue>A</test:enumValue>
+        <test:fvalue>0</test:fvalue>
+        <test:dvalue>0</test:dvalue>
+        <test:bvalue>true</test:bvalue>
+        <test:lvalue>23</test:lvalue>
+        <test:svalue>4</test:svalue>
+        <test:bigDecimalValue>10</test:bigDecimalValue>
+        <test:noField>7</test:noField>
+        <test:elValue>
+            <value>#{elValue}</value>
+        </test:elValue>
+        <test:elInnerTextValue>#{elValue}</test:elInnerTextValue>
+    </test:FieldValueBean>
+
+    <test:FieldValueBean ivalue="10" stringValue="hello world" enumValue="A" fvalue="0" dvalue="0" bvalue="true"
+                         lvalue="23" svalue="4" bigDecimalValue="10" noField="7">
+        <replaces/>
+        <test:init>
+            <Inject/>
+        </test:init>
+        <test:FieldsetQualifier/>
+    </test:FieldValueBean>
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/injection/producer-field-value-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/injection/producer-field-value-beans.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.injection">
+
+
+    <test:ProducerQualifier>
+        <Qualifier/>
+    </test:ProducerQualifier>
+
+    <test:ProducerBean>
+        <replaces/>
+        <test:value>
+            <Produces/>
+            <test:ProducerQualifier/>
+            <value>hello world</value>
+        </test:value>
+    </test:ProducerBean>
+
+    <test:RecieverBean>
+        <replaces/>
+        <test:value>
+            <test:ProducerQualifier/>
+            <Inject/>
+        </test:value>
+    </test:RecieverBean>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/injection/qualifier-attributes-test-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/injection/qualifier-attributes-test-beans.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.injection">
+
+    <test:OtherQualifier>
+        <Qualifier/>
+    </test:OtherQualifier>
+
+    <test:QualifiedBean1>
+        <test:OtherQualifier value1="AA" value2="1">A</test:OtherQualifier>
+    </test:QualifiedBean1>
+
+    <test:QualifiedBean2>
+        <test:OtherQualifier value1="BB" value2="2" value="B"/>
+    </test:QualifiedBean2>
+
+    <test:QualifierTestBean>
+        <replaces/>
+        <test:bean1>
+            <test:OtherQualifier value1="AA" value2="1" value="A"/>
+            <Inject/>
+        </test:bean1>
+        <test:bean2>
+            <test:OtherQualifier value1="BB" value2="2">B</test:OtherQualifier>
+            <Inject/>
+        </test:bean2>
+    </test:QualifierTestBean>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/interceptor/interceptor-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/interceptor/interceptor-beans.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:s="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.interceptor">
+
+    <test:InterceptedBean>
+        <replaces/>
+        <test:method>
+            <test:Binding/>
+        </test:method>
+    </test:InterceptedBean>
+    
+    <test:Binding>
+        <s:InterceptorBinding/>
+    </test:Binding>
+
+    <test:InterceptorBean>
+        <s:replaces/>
+        <s:Interceptor/>
+        <test:Binding/>
+        <test:myMethod>
+            <s:AroundInvoke/>
+        </test:myMethod>
+    </test:InterceptorBean>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/method/method-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/method/method-beans.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee" xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.method">
+
+
+    <test:Qualifier1>
+        <Qualifier/>
+    </test:Qualifier1>
+
+    <test:Qualifier2>
+        <Qualifier/>
+    </test:Qualifier2>
+
+    <test:Qualifier3>
+        <Qualifier/>
+    </test:Qualifier3>
+
+    <test:MethodBean>
+        <test:method>
+            <Produces/>
+        </test:method>
+
+        <test:method>
+            <Produces/>
+            <test:Qualifier1/>
+            <parameters>
+                <test:MethodValueBean>
+                    <test:Qualifier2/>
+                </test:MethodValueBean>
+            </parameters>
+        </test:method>
+
+        <test:method>
+            <Produces/>
+            <test:Qualifier1/>
+            <parameters>
+                <array dimensions="2">
+                    <test:Qualifier2/>
+                    <test:MethodValueBean/>
+                </array>
+            </parameters>
+        </test:method>
+
+        <test:method>
+            <Produces/>
+            <test:Qualifier2/>
+            <parameters>
+                <Instance>
+                    <test:Qualifier2/>
+                </Instance>
+            </parameters>
+        </test:method>
+        <test:method>
+            <Produces/>
+            <test:Qualifier3/>
+            <parameters>
+                <Instance>
+                    <test:Qualifier2/>
+                </Instance>
+                <Instance>
+                    <test:Qualifier2/>
+                </Instance>
+            </parameters>
+        </test:method>
+    </test:MethodBean>
+
+    <test:MethodTarget>
+        <replaces/>
+        <test:value1>
+            <Inject/>
+        </test:value1>
+        <test:value2>
+            <Inject/>
+            <test:Qualifier1/>
+        </test:value2>
+        <test:value3>
+            <Inject/>
+            <test:Qualifier2/>
+        </test:value3>
+        <test:longValue>
+            <Inject/>
+            <test:Qualifier1/>
+        </test:longValue>
+    </test:MethodTarget>
+
+    <test:MethodValueBean>
+        <test:Qualifier2/>
+    </test:MethodValueBean>
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/method/primitive-method-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/method/primitive-method-beans.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.method">
+
+
+    <test:Qualifier1>
+        <Qualifier/>
+    </test:Qualifier1>
+
+    <test:Qualifier2>
+        <Qualifier/>
+    </test:Qualifier2>
+
+    <test:PrimitiveBean>
+        <test:add>
+            <Produces/>
+            <test:Qualifier1/>
+            <parameters>
+                <int/>
+            </parameters>
+        </test:add>
+        <test:add>
+            <Produces/>
+            <test:Qualifier2/>
+            <parameters>
+                <array>
+                    <int/>
+                </array>
+            </parameters>
+        </test:add>
+    </test:PrimitiveBean>
+
+    <test:PrimitiveValueProducer>
+        <test:value>
+            <Produces/>
+        </test:value>
+
+        <test:value2>
+            <Produces/>
+        </test:value2>
+    </test:PrimitiveValueProducer>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/producer/multiple-producers.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/producer/multiple-producers.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.producer">
+
+
+    <test:Producer>
+        <replaces/>
+        <test:value>
+            <Produces/>
+            <test:ProducerQualifier value="1"/>
+            <value>1</value>
+        </test:value>
+        <test:meth>
+            <Produces/>
+            <test:ProducerQualifier value="3"/>
+        </test:meth>
+    </test:Producer>
+
+    <test:Producer>
+        <test:value>
+            <Produces/>
+            <test:ProducerQualifier value="2"/>
+            <value>2</value>
+        </test:value>
+        <test:meth>
+            <Produces/>
+            <test:ProducerQualifier value="4"/>
+        </test:meth>
+    </test:Producer>
+
+
+    <test:Reciever>
+        <replaces/>
+        <test:val1>
+            <Inject/>
+            <test:ProducerQualifier value="1"/>
+        </test:val1>
+        <test:val2>
+            <Inject/>
+            <test:ProducerQualifier value="2"/>
+        </test:val2>
+        <test:meth1>
+            <Inject/>
+            <test:ProducerQualifier value="3"/>
+        </test:meth1>
+        <test:meth2>
+            <Inject/>
+            <test:ProducerQualifier value="4"/>
+        </test:meth2>
+
+    </test:Reciever>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/simple/empty-root-namespace-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/simple/empty-root-namespace-beans.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:s="urn:java:ee" xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.simple">
+
+    <test:Bean1>
+        <s:replaces/>
+        <test:bean2>
+            <s:Inject/>
+        </test:bean2>
+
+        <test:pcMethod>
+            <s:PostConstruct/>
+        </test:pcMethod>
+
+        <test:value>
+            <s:Produces/>
+        </test:value>
+    </test:Bean1>
+
+    <test:Bean2>
+        <s:replaces/>
+        <test:produceBean3>
+            <s:Produces/>
+            <s:parameters/>
+        </test:produceBean3>
+        <test:produceBean3>test value</test:produceBean3>
+    </test:Bean2>
+
+    <test:OverriddenBean>
+        <s:replaces/>
+        <s:Named>someBean</s:Named>
+    </test:OverriddenBean>
+
+    <test:ExtendedBean>
+        <s:modifies/>
+        <test:ExtendedQualifier2/>
+    </test:ExtendedBean>
+
+    <test:ScopeOverrideBean>
+        <s:modifies/>
+        <s:ApplicationScoped/>
+    </test:ScopeOverrideBean>
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/simple/simple-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/simple/simple-beans.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.simple">
+
+
+    <test:Bean1>
+        <replaces/>
+        <test:bean2>
+            <Inject/>
+        </test:bean2>
+
+        <test:pcMethod>
+            <PostConstruct/>
+        </test:pcMethod>
+
+        <test:value>
+            <Produces/>
+        </test:value>
+    </test:Bean1>
+
+    <test:Bean2>
+        <replaces/>
+        <test:produceBean3>
+            <Produces/>
+            <parameters/>
+        </test:produceBean3>
+        <test:produceBean3>test value</test:produceBean3>
+    </test:Bean2>
+
+    <test:OverriddenBean>
+        <replaces/>
+        <Named>someBean</Named>
+    </test:OverriddenBean>
+
+    <test:ExtendedBean>
+        <modifies/>
+        <test:ExtendedQualifier2/>
+    </test:ExtendedBean>
+
+    <test:ScopeOverrideBean>
+        <modifies/>
+        <ApplicationScoped/>
+    </test:ScopeOverrideBean>
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/stereotype/stereotype-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/stereotype/stereotype-beans.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:s="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.stereotype"
+       xmlns:int="urn:java:org.jboss.solder.config.xml.test.common.interceptor">    
+
+    <test:Stereotype1>
+        <Stereotype/>
+        <int:Binding/>
+    </test:Stereotype1>
+    
+    <int:Binding>
+        <s:InterceptorBinding/>
+    </int:Binding>
+
+    <int:InterceptorBean>
+        <s:replaces/>
+        <s:Interceptor/>
+        <int:Binding/>
+        <int:myMethod>
+            <s:AroundInvoke/>
+        </int:myMethod>
+    </int:InterceptorBean>
+
+    <int:InterceptedBean>
+        <replaces/>
+        <test:Stereotype1/>
+    </int:InterceptedBean>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/types/types-test-beans.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/types/types-test-beans.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.types">
+
+
+    <test:TypeInjectedClass>
+        <replaces/>
+        <test:value>
+            <Inject/>
+            <Exact>org.jboss.solder.config.xml.test.common.types.AllowedType</Exact>
+        </test:value>
+        <test:create>
+            <Inject/>
+            <parameters>
+                <test:SomeInterface>
+                    <Exact>org.jboss.solder.config.xml.test.common.types.RestrictedType</Exact>
+                </test:SomeInterface>
+            </parameters>
+        </test:create>
+    </test:TypeInjectedClass>
+
+</beans>

--- a/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/virtualproducer/virtualproducer.xml
+++ b/testsuite/src/test/resources/org/jboss/solder/config/xml/test/common/virtualproducer/virtualproducer.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="urn:java:ee"
+       xmlns:test="urn:java:org.jboss.solder.config.xml.test.common.virtualproducer">
+
+    <String>
+        <Produces/>
+        <test:VirtualProducerQualifier/>
+        <value>Hello World</value>
+    </String>
+
+</beans>


### PR DESCRIPTION
Import of the seam config testsuite, converted to arquillian.

I had to change how the whole testsuite works while converting them to arquillian, so you should better review it before merging...   (diff is mostly the same as https://github.com/seam/config/pull/12/)
