### PR TITLE
SEAM-107 Testcase for HttpSessionStatus

### DIFF
--- a/testsuite/src/test/java/org/jboss/solder/servlet/test/weld/http/HttpSessionStatusTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/servlet/test/weld/http/HttpSessionStatusTest.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.servlet.test.weld.http;
+
+import javax.inject.Inject;
+
+import junit.framework.Assert;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.solder.servlet.http.HttpSessionStatus;
+import org.jboss.solder.servlet.test.weld.util.Deployments;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ */
+@RunWith(Arquillian.class)
+public class HttpSessionStatusTest {
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return Deployments
+                .createMockableBeanWebArchive();
+    }
+
+    @Inject
+    HttpSessionStatus httpSessionStatus;
+
+    @Test
+    public void should_inject_value_for_explicit_http_param() {
+        Assert.assertTrue(httpSessionStatus.isActive());
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/servlet/test/weld/http/HttpSessionStatusTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/servlet/test/weld/http/HttpSessionStatusTest.java
@@ -42,8 +42,8 @@ public class HttpSessionStatusTest {
     HttpSessionStatus httpSessionStatus;
 
     @Test
-    public void should_inject_value_for_explicit_http_param() {
-        Assert.assertTrue(httpSessionStatus.isActive());
+    public void checkIfHttpSessionStatusIsActive() {
+        httpSessionStatus.isActive();
     }
 
 }


### PR DESCRIPTION
Proves that HttpSessionStatus does not work (at least not how it's documented in the manual).
There are no previous tests for HttpSessionStatus.

This test fails with
 WELD-000052 Cannot return null from a non-dependent producer method:  [method] @Produces @Typed @RequestScoped protected org.jboss.solder.servlet.http.ImplicitHttpServletObjectsProducer.getHttpServletRequest()

https://issues.jboss.org/browse/SEAM-107
