### PR TITLE
[SOLDER-240]: ServletContextAttributeProvider uses wrong servlet ctx. attribute name to lookup the bean manager

### DIFF
--- a/impl/src/main/java/org/jboss/solder/servlet/beanManager/ServletContextAttributeProvider.java
+++ b/impl/src/main/java/org/jboss/solder/servlet/beanManager/ServletContextAttributeProvider.java
@@ -42,8 +42,21 @@ public class ServletContextAttributeProvider implements BeanManagerProvider {
     }
 
     public BeanManager getBeanManager() {
+
         if (servletContext.get() != null) {
-            return (BeanManager) servletContext.get().getAttribute(BeanManager.class.getName());
+
+            ServletContext context = servletContext.get();
+
+            // the default attribute for the BeanManager
+            BeanManager beanManager = (BeanManager) context.getAttribute(BeanManager.class.getName());
+
+            // also try an attribute used in early versions of Weld 1.1.x
+            if (beanManager == null) {
+                beanManager = (BeanManager) context.getAttribute("org.jboss.weld.environment.servlet.javax.enterprise.inject.spi.BeanManager");
+            }
+
+            return beanManager;
+
         }
         return null;
     }

--- a/impl/src/main/java/org/jboss/solder/servlet/event/ImplicitServletObjectsHolder.java
+++ b/impl/src/main/java/org/jboss/solder/servlet/event/ImplicitServletObjectsHolder.java
@@ -72,6 +72,7 @@ public class ImplicitServletObjectsHolder {
     protected void requestInitialized(@Observes @Initialized final InternalServletRequestEvent e) {
         ServletRequest req = e.getServletRequest();
         log.servletRequestInitialized(req);
+        ServletContextAttributeProvider.setServletContext(servletCtx);
         if (req instanceof HttpServletRequest) {
             requestCtx.set(new HttpServletRequestContext(req));
         } else {
@@ -81,6 +82,7 @@ public class ImplicitServletObjectsHolder {
 
     protected void requestDestroyed(@Observes @Destroyed final InternalServletRequestEvent e) {
         log.servletRequestDestroyed(e.getServletRequest());
+        ServletContextAttributeProvider.setServletContext(null);
         requestCtx.set(null);
     }
 


### PR DESCRIPTION
Please refer to SOLDER-240 for details regarding this pull request:

https://issues.jboss.org/browse/SOLDER-240
