### PR TITLE
SOLDER-181 working jacoco profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.jboss.seam</groupId>
       <artifactId>seam-parent</artifactId>
-      <version>17</version>
+      <version>18-SNAPSHOT</version>
    </parent>
 
    <groupId>org.jboss.solder</groupId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -231,11 +231,6 @@
         <profile>
             <id>jacoco</id>
 
-            <properties>
-                <version.jacoco>0.5.3.201107060350</version.jacoco>
-                <version.shrinkwrap_shrinkwrap>1.0.0-beta-6</version.shrinkwrap_shrinkwrap>
-            </properties>
-
             <dependencies>
                 <dependency>
                     <groupId>org.jboss.arquillian.extension</groupId>
@@ -245,28 +240,8 @@
                 <dependency>
                     <groupId>org.jacoco</groupId>
                     <artifactId>org.jacoco.core</artifactId>
-                    <version>${version.jacoco}</version>
                     <scope>provided</scope>
                 </dependency>
-
-                <dependency>
-                    <groupId>org.jboss.shrinkwrap</groupId>
-                    <artifactId>shrinkwrap-api</artifactId>
-                    <version>${version.shrinkwrap_shrinkwrap}</version>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.jboss.shrinkwrap</groupId>
-                    <artifactId>shrinkwrap-impl-base</artifactId>
-                    <version>${version.shrinkwrap_shrinkwrap}</version>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.jboss.shrinkwrap</groupId>
-                    <artifactId>shrinkwrap-spi</artifactId>
-                    <version>${version.shrinkwrap_shrinkwrap}</version>
-                </dependency>
-
             </dependencies>
 
             <build>
@@ -294,7 +269,6 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>${version.jacoco}</version>
                         <executions>
                             <execution>
                                 <goals>


### PR DESCRIPTION
This patch depends on updates to Seam Parent https://github.com/seam/parent/pull/10  and thus changes seam-parent version to 18-SNAPSHOT
