### PR TITLE
SOLDER-307 make the HttpSessionStatusTest run on JBossAS profile only

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -123,6 +123,9 @@
                                 <arquillian.launch>weld-ee-embedded-1.1</arquillian.launch>
                                 <arquillian>weld-ee-embedded-1.1</arquillian>
                             </systemProperties>
+                            <excludes>
+                               <exclude>**/jbossas/**</exclude>
+                            </excludes>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -194,6 +197,7 @@
                      <configuration>
                         <excludes>
                            <exclude>**/weld/**</exclude>
+                           <exclude>**/jbossas/**</exclude>
                         </excludes>
                      </configuration>
                   </plugin>
@@ -227,6 +231,7 @@
                      <configuration>
                         <excludes>
                            <exclude>**/weld/**</exclude>
+                           <exclude>**/jbossas/**</exclude>
                         </excludes>
                      </configuration>
                   </plugin>

--- a/testsuite/src/test/java/org/jboss/solder/servlet/test/jbossas/HttpSessionStatusTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/servlet/test/jbossas/HttpSessionStatusTest.java
@@ -14,10 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.solder.servlet.test;
+package org.jboss.solder.servlet.test.jbossas;
 
 import javax.inject.Inject;
 
+import org.jboss.arquillian.container.test.api.OverProtocol;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -31,7 +32,7 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class HttpSessionStatusTest {
 
-    @Deployment
+    @Deployment @OverProtocol("Servlet 3.0")
     public static Archive<?> createDeployment() {
         return Deployments
                 .createMockableBeanWebArchive();

--- a/testsuite/src/test/resources/arquillian.xml
+++ b/testsuite/src/test/resources/arquillian.xml
@@ -26,15 +26,8 @@
     <container qualifier="weld-ee-embedded-1.1">
     </container>
 
-    <defaultProtocol type="Servlet 3.0"/>
-
     <container qualifier="jbossas-managed-7">
-      <!--
-        <protocol type="jmx-as7">
-            <property name="executionType">REMOTE</property>
-        </protocol>
-      -->
-        <configuration>
+       <configuration>
             <property name="javaVmArguments">-client -noverify -XX:+UseFastAccessorMethods -Xms64m -Xmx1024m -XX:MaxPermSize=512m</property>
        </configuration>
     </container>


### PR DESCRIPTION
make it @OverProtocol("Servlet 3.0"), so we don't make the Servlet 3.0 default for all tests.
