### PR TITLE
[SOLDER-265] Provide a portable means to access web.xml without the ServletContext

### DIFF
--- a/api/src/main/java/org/jboss/solder/servlet/webxml/WebXmlLocator.java
+++ b/api/src/main/java/org/jboss/solder/servlet/webxml/WebXmlLocator.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.servlet.webxml;
+
+import java.net.URL;
+
+import org.jboss.solder.util.Sortable;
+
+/**
+ * 
+ * SPI for finding the location of <code>web.xml</code>.
+ * 
+ * @author Christian Kaltepoth <christian@kaltepoth.de>
+ * 
+ */
+public interface WebXmlLocator extends Sortable {
+
+    /**
+     * Returns the guessed location of <code>web.xml</code>.
+     * 
+     * @param classLoader The classloader to use for resource lookups
+     * @return The location of <code>web.xml</code> or <code>null</code> if the location could not be identified
+     */
+    URL getWebXmlLocation(ClassLoader classLoader);
+
+}

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -96,6 +96,13 @@
       </dependency>         
 
       <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-core</artifactId>
+         <version>1.8.5</version>
+         <scope>test</scope>
+      </dependency>      
+
+      <dependency>
          <groupId>org.hamcrest</groupId>
          <artifactId>hamcrest-core</artifactId>
       </dependency>

--- a/impl/src/main/java/org/jboss/solder/servlet/webxml/DirectoryNameWebXmlLocator.java
+++ b/impl/src/main/java/org/jboss/solder/servlet/webxml/DirectoryNameWebXmlLocator.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.servlet.webxml;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.jboss.solder.logging.Logger;
+
+/**
+ * <p>
+ * This implementation of {@link WebXmlLocator} will try to identify the location of <code>web.xml</code> by searching for a
+ * known resource on the classpath and trying to find the <code>WEB-INF</code> directory in its path name. This will typically
+ * work if the known resource in located in a JAR file inside the <code>WEB-INF/lib</code> directory.
+ * </p>
+ * 
+ * <p>
+ * Compared to {@link URLClassLoaderWebXmlLocator} this implementation works fine even for containers like JBoss AS6 and AS7.
+ * </p>
+ * 
+ * @author Christian Kaltepoth <christian@kaltepoth.de>
+ * 
+ */
+public class DirectoryNameWebXmlLocator implements WebXmlLocator {
+
+    private final Logger log = Logger.getLogger(DirectoryNameWebXmlLocator.class);
+
+    @Override
+    public int getPrecedence() {
+        return 50;
+    }
+
+    @Override
+    public URL getWebXmlLocation(ClassLoader classLoader) {
+
+        // try to load a resource that MUST exist
+        String relativeResourceName = this.getClass().getName().replace('.', '/') + ".class";
+        URL knownResource = classLoader.getResource(relativeResourceName);
+
+        // we cannot proceed without that resource
+        if (knownResource == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Could not find resource: " + relativeResourceName);
+            }
+            return null;
+        }
+
+        // we will now work on the absolute path of this URL
+        String url = knownResource.toString();
+
+        if (log.isTraceEnabled()) {
+            log.trace("Found known resource: " + url);
+        }
+
+        // is the resource located inside a JAR file? Remove the jar-specific part.
+        if (url.startsWith("jar:") && url.contains("!")) {
+
+            url = url.substring(4, url.lastIndexOf("!"));
+
+            if (log.isTraceEnabled()) {
+                log.trace("Location of JAR file containing the resource: " + url);
+            }
+
+        }
+
+        // should always work as the URL is built using an existing URL
+        try {
+
+            // try to locate the WEB-INF directory
+            int i = url.lastIndexOf("/WEB-INF/lib/");
+            if (i >= 0) {
+                return new URL(url.substring(0, i) + "/WEB-INF/web.xml");
+            }
+
+        } catch (MalformedURLException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to create URL instance!", e);
+            }
+        }
+        return null;
+
+    }
+}

--- a/impl/src/main/java/org/jboss/solder/servlet/webxml/URLClassLoaderWebXmlLocator.java
+++ b/impl/src/main/java/org/jboss/solder/servlet/webxml/URLClassLoaderWebXmlLocator.java
@@ -1,0 +1,119 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.servlet.webxml;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.jboss.solder.logging.Logger;
+import org.jboss.solder.servlet.webxml.WebXmlLocator;
+
+/**
+ * This implementation of {@link WebXmlLocator} will try to identify the location of <code>web.xml</code> by examining the URLs
+ * the classloader uses for loading classes. This will only work if the classloader is a {@link URLClassLoader}.
+ * 
+ * @author Christian Kaltepoth <christian@kaltepoth.de>
+ * 
+ */
+public class URLClassLoaderWebXmlLocator implements WebXmlLocator {
+
+    private final Logger log = Logger.getLogger(URLClassLoaderWebXmlLocator.class);
+
+    @Override
+    public int getPrecedence() {
+        return 100;
+    }
+
+    @Override
+    public URL getWebXmlLocation(ClassLoader classLoader) {
+
+        // this class only works for URLClassLoaders
+        if (classLoader instanceof URLClassLoader) {
+
+            URLClassLoader urlClassLoader = (URLClassLoader) classLoader;
+
+            // get the URLs of the classloader
+            for (URL classLoaderUrl : urlClassLoader.getURLs()) {
+
+                // try this URL to locate the web.xml
+                URL possibleWebXmlLocation = processClassLoaderSearchPath(classLoaderUrl);
+
+                // we will use the first result we get
+                if (possibleWebXmlLocation != null) {
+                    return possibleWebXmlLocation;
+                }
+
+            }
+
+        }
+
+        // log class loader type in all other cases
+        else {
+            if (log.isTraceEnabled()) {
+                log.trace("Context class loader is not an URLClassLoader but: "
+                        + (classLoader != null ? classLoader.getClass().getName() : "null"));
+            }
+        }
+
+        return null;
+
+    }
+
+    /**
+     * Try to locate the web.xml using the supplied classloader URL.
+     * 
+     * @param classPathUrl The {@link URL} the classloader uses to look for classes
+     * @return The guessed location of web.xml or <code>null</code> if it could not be determined
+     */
+    private URL processClassLoaderSearchPath(URL classPathUrl) {
+
+        // we use string comparisons here
+        String location = classPathUrl.toString();
+
+        // ignore JAR files as they don't help us
+        if (location.endsWith(".jar")) {
+            return null;
+        }
+
+        if (log.isTraceEnabled()) {
+            log.trace("Found URL of directory: " + location);
+        }
+
+        // should always work as the URL is built using an existing URL
+        try {
+
+            // Works for most containers like Tomcat, Jetty and Glassfish
+            if (location.endsWith("/WEB-INF/classes/")) {
+                return new URL(location.replaceAll("classes/$", "web.xml"));
+            }
+
+            // special hack for the Maven Jetty plugin
+            if (location.endsWith("/target/classes/")) {
+                return new URL(location.replaceAll("target/classes/$", "src/main/webapp/WEB-INF/web.xml"));
+            }
+            
+        } catch (MalformedURLException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to create URL instance!", e);
+            }
+        }
+        return null;
+
+    }
+
+}

--- a/impl/src/main/resources/META-INF/services/org.jboss.solder.servlet.webxml.WebXmlLocator
+++ b/impl/src/main/resources/META-INF/services/org.jboss.solder.servlet.webxml.WebXmlLocator
@@ -1,0 +1,2 @@
+org.jboss.solder.servlet.webxml.URLClassLoaderWebXmlLocator
+org.jboss.solder.servlet.webxml.DirectoryNameWebXmlLocator

--- a/impl/src/test/java/org/jboss/solder/test/servlet/webxml/DirectoryNameWebXmlLocatorTest.java
+++ b/impl/src/test/java/org/jboss/solder/test/servlet/webxml/DirectoryNameWebXmlLocatorTest.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.test.servlet.webxml;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+
+import java.net.URL;
+
+import org.jboss.solder.servlet.webxml.DirectoryNameWebXmlLocator;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit test for {@link DirectoryNameWebXmlLocator}. Please note that this test won't use the 'vfs' protocol because
+ * this won't work in a simple unit test outside of a container. We will simply use the 'file' protocol instead, which
+ * will also work fine to verify the results.
+ *
+ * @author Christian Kaltepoth <christian@kaltepoth.de>
+ *
+ */
+public class DirectoryNameWebXmlLocatorTest {
+
+    @Test
+    public void testResourceFromWebLibDirectoryAS7() throws Exception {
+
+        final String resourceName = DirectoryNameWebXmlLocator.class.getName().replace('.', '/') + ".class";
+        final URL resourceUrl = new URL("file:/jboss-home/server/default/deploy/seam-faces-tests.war/WEB-INF/lib/seam-faces-3.1.0-SNAPSHOT.jar/" + resourceName);
+
+        ClassLoader classLoader = Mockito.mock(ClassLoader.class);
+        Mockito.when(classLoader.getResource(resourceName)).thenReturn(resourceUrl);
+
+        DirectoryNameWebXmlLocator locator = new DirectoryNameWebXmlLocator();
+        URL resultUrl = locator.getWebXmlLocation(classLoader);
+
+        assertNotNull(resultUrl);
+        assertEquals("file:/jboss-home/server/default/deploy/seam-faces-tests.war/WEB-INF/web.xml", resultUrl.toString());
+
+    }
+
+    @Test
+    public void testResourceFromWebLibDirectoryAS6() throws Exception {
+
+        final String resourceName = DirectoryNameWebXmlLocator.class.getName().replace('.', '/') + ".class";
+        final URL resourceUrl = new URL("file:/content/seam-faces-tests.war/WEB-INF/lib/seam-faces-3.1.0-SNAPSHOT.jar/" + resourceName);
+
+        ClassLoader classLoader = Mockito.mock(ClassLoader.class);
+        Mockito.when(classLoader.getResource(resourceName)).thenReturn(resourceUrl);
+
+        DirectoryNameWebXmlLocator locator = new DirectoryNameWebXmlLocator();
+        URL resultUrl = locator.getWebXmlLocation(classLoader);
+
+        assertNotNull(resultUrl);
+        assertEquals("file:/content/seam-faces-tests.war/WEB-INF/web.xml", resultUrl.toString());
+
+    }
+
+    @Test
+    public void testResourceFromWebLibDirectoryTomcat7() throws Exception {
+
+        final String resourceName = DirectoryNameWebXmlLocator.class.getName().replace('.', '/') + ".class";
+        final URL resourceUrl = new URL("jar:file:/tomcat-home/webapps/seam-faces-tests/WEB-INF/lib/seam-faces-3.1.0-SNAPSHOT.jar!/" + resourceName);
+
+        ClassLoader classLoader = Mockito.mock(ClassLoader.class);
+        Mockito.when(classLoader.getResource(resourceName)).thenReturn(resourceUrl);
+
+        DirectoryNameWebXmlLocator locator = new DirectoryNameWebXmlLocator();
+        URL resultUrl = locator.getWebXmlLocation(classLoader);
+
+        assertNotNull(resultUrl);
+        assertEquals("file:/tomcat-home/webapps/seam-faces-tests/WEB-INF/web.xml", resultUrl.toString());
+
+    }
+
+}

--- a/impl/src/test/java/org/jboss/solder/test/servlet/webxml/URLClassLoaderWebXmlLocatorTest.java
+++ b/impl/src/test/java/org/jboss/solder/test/servlet/webxml/URLClassLoaderWebXmlLocatorTest.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.test.servlet.webxml;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.jboss.solder.servlet.webxml.URLClassLoaderWebXmlLocator;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class URLClassLoaderWebXmlLocatorTest {
+
+    @Test
+    public void testNotAnUrlClassLoader() {
+
+        ClassLoader classLoader = Mockito.mock(ClassLoader.class);
+
+        URL result = new URLClassLoaderWebXmlLocator().getWebXmlLocation(classLoader);
+
+        assertNull(result);
+
+    }
+
+    @Test
+    public void testUrlClassLoaderWithoutUrls() {
+
+        URLClassLoader classLoader = Mockito.mock(URLClassLoader.class);
+        Mockito.when(classLoader.getURLs()).thenReturn(new URL[0]);
+
+        URL result = new URLClassLoaderWebXmlLocator().getWebXmlLocation(classLoader);
+
+        assertNull(result);
+
+    }
+
+    @Test
+    public void testUrlClassLoaderWithoutHelpfulUrls() throws MalformedURLException {
+
+        URLClassLoader classLoader = Mockito.mock(URLClassLoader.class);
+        Mockito.when(classLoader.getURLs()).thenReturn(new URL[] { new URL("file:/tmp/test.jar") });
+
+        URL result = new URLClassLoaderWebXmlLocator().getWebXmlLocation(classLoader);
+
+        assertNull(result);
+
+    }
+
+    @Test
+    public void testUrlClassLoaderWithClassesDirectory() throws MalformedURLException {
+
+        URLClassLoader classLoader = Mockito.mock(URLClassLoader.class);
+        Mockito.when(classLoader.getURLs()).thenReturn(new URL[] {
+                new URL("file:/tmp/myapp/WEB-INF/lib/test.jar"),
+                new URL("file:/tmp/myapp/WEB-INF/classes/"),
+                new URL("file:/tmp/myapp/WEB-INF/lib/test2.jar")
+        });
+
+        URL result = new URLClassLoaderWebXmlLocator().getWebXmlLocation(classLoader);
+
+        assertNotNull(result);
+        assertEquals("file:/tmp/myapp/WEB-INF/web.xml", result.toString());
+
+    }
+
+    @Test
+    public void testUrlClassLoaderWithMavenJettyPlugin() throws MalformedURLException {
+
+        URLClassLoader classLoader = Mockito.mock(URLClassLoader.class);
+        Mockito.when(classLoader.getURLs()).thenReturn(new URL[] {
+                new URL("file:/home/user/.m2/repository/group/artifact/1.0/artifact-1.0.jar"),
+                new URL("file:/somewhere/myapp/target/classes/"),
+                new URL("file:/home/user/.m2/repository/group/artifact2/1.0/artifact2-1.0.jar"),
+        });
+
+        URL result = new URLClassLoaderWebXmlLocator().getWebXmlLocation(classLoader);
+
+        assertNotNull(result);
+        assertEquals("file:/somewhere/myapp/src/main/webapp/WEB-INF/web.xml", result.toString());
+
+    }
+
+}


### PR DESCRIPTION
This pull request contains the WebXmlLocator I wrote for Seam Faces. As discussed with Jason this should be moved to Solder as it may be useful for other CDI extensions as well.

See this ticket for details:

https://issues.jboss.org/browse/SOLDER-265
