### PR TITLE
Added WebXmlFinder to simplify the use of WebXmlLocator

### DIFF
--- a/api/src/main/java/org/jboss/solder/servlet/webxml/WebXmlFinder.java
+++ b/api/src/main/java/org/jboss/solder/servlet/webxml/WebXmlFinder.java
@@ -1,0 +1,114 @@
+package org.jboss.solder.servlet.webxml;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.servlet.ServletContext;
+
+import org.jboss.solder.util.Sortable;
+import org.jboss.solder.util.service.ServiceLoader;
+
+/**
+ * <p>
+ * A utility for classes that need to access <code>web.xml</code>.
+ * </p>
+ * <p>
+ * This class provides a way to obtain the location of the <code>web.xml</code> without using the {@link ServletContext}. This
+ * is especially interesting for extensions that are executed very early in the CDI startup process because the
+ * {@link ServletContext} may not be available in this stage.
+ * </p>
+ * <p>
+ * The class makes use of the {@link WebXmlLocator} SPI to actually find the <code>web.xml</code>. This allows to write custom
+ * implementations optimized for specific environments.
+ * </p>
+ * 
+ * @author Christian Kaltepoth
+ * @see WebXmlLocator
+ * 
+ */
+public class WebXmlFinder {
+
+    /**
+     * set as soon as the lookup has been performed
+     */
+    private volatile boolean lookupDone = false;
+
+    /**
+     * location of web.xml which is looked up lazily
+     */
+    private volatile URL webXmlLocation = null;
+
+    /**
+     * Try to obtain the location of <code>web.xml</code>. If the lookup hasn't been performed this method will consult all
+     * implementations of {@link WebXmlLocator} until it gets a result.
+     * 
+     * @return The location of <code>web.xml</code> or <code>null</code> if could not be found
+     */
+    public URL getWebXmlLocation() {
+
+        if (!lookupDone) {
+            lookupWebXmlLocation();
+        }
+
+        return webXmlLocation;
+
+    }
+
+    /**
+     * Checks whether {@link WebXmlFinder} was able to find the location of <code>web.xml</code>.
+     * 
+     * @return <code>true</code> if the location could be found
+     */
+    public boolean isWebXmlLocationAvailable() {
+
+        if (!lookupDone) {
+            lookupWebXmlLocation();
+        }
+
+        return webXmlLocation != null;
+
+    }
+
+    /**
+     * internal method to lazily perform the lookup of the <code>web.xml</code> location
+     */
+    private synchronized void lookupWebXmlLocation() {
+
+        if (!lookupDone) {
+
+            // build sorted list of locator implementations
+            List<WebXmlLocator> locators = new ArrayList<WebXmlLocator>();
+            for (Iterator<WebXmlLocator> iter = ServiceLoader.load(WebXmlLocator.class).iterator(); iter.hasNext();) {
+                locators.add(iter.next());
+            }
+            Collections.sort(locators, new Sortable.Comparator());
+
+            // prefer the context classloader
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            if (classLoader == null) {
+                classLoader = this.getClass().getClassLoader();
+            }
+
+            // process each locator one by one
+            for (WebXmlLocator locator : locators) {
+
+                // execute the SPI implementation
+                webXmlLocation = locator.getWebXmlLocation(classLoader);
+
+                // accept the first result
+                if (webXmlLocation != null) {
+                    break;
+                }
+
+            }
+
+            lookupDone = true;
+
+        }
+
+    }
+
+}

--- a/docs/src/main/docbook/en-US/master.xml
+++ b/docs/src/main/docbook/en-US/master.xml
@@ -65,6 +65,7 @@
     <xi:include href="servlet-injectable_refs.xml"/>
     <xi:include href="servlet-exception_handling.xml"/>
     <xi:include href="servlet-beanmanager.xml"/>
+    <xi:include href="servlet-webxml.xml"/>
   </part>
   <toc/>
 </book>

--- a/docs/src/main/docbook/en-US/servlet-webxml.xml
+++ b/docs/src/main/docbook/en-US/servlet-webxml.xml
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  JBoss, Home of Professional Open Source
+  Copyright 2010, Red Hat Middleware LLC, and individual contributors
+  by the @authors tag. See the copyright.txt in the distribution for a
+  full listing of individual contributors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" []>
+<chapter id="webxml">
+  <title>Retrieving the location of <filename>web.xml</filename></title>
+  
+  <para>
+    Sometimes developers need to access configuration parameters of a web application. Typically the
+    <classname>ServletContext</classname> is used to obtain context parameters, servlet mappings and other information. 
+    Unfortunately the <classname>ServletContext</classname> cannot be accessed in all situations. 
+    Especially CDI extensions can be problematic in this regard as they are executed during a stage in the 
+    application startup in which the <classname>ServletContext</classname> may not have been created yet.
+  </para>
+  
+  <para>
+    In such situations the only way for developers to access information like servlet context parameters is to
+    manually parse the <filename>web.xml</filename> of the application. But to load the <filename>web.xml</filename>
+    one would typically have to get it's location using <classname>ServletContext.getResource()</classname> which
+    isn't possible due to the missing <classname>ServletContext</classname>.
+  </para>
+
+  <para>
+    Solder offers some help in this situation. The class <classname>WebXmlFinder</classname> provides a simple
+    way to obtain the location of the application's <filename>web.xml</filename>. Under the covers this
+    class uses the SPI <classname>WebXmlLocator</classname> to retrieve the location. 
+  </para>
+  
+  <para>
+    The following example shows how to use this class:
+  </para>
+
+  <programlisting role="JAVA"><![CDATA[
+WebXmlFinder finder = new WebXmlFinder();
+
+if (finder.isWebXmlLocationAvailable()) {
+
+  URL webXml = finder.getWebXmlLocation();
+
+  // parse the web.xml file
+
+}
+]]>
+  </programlisting>
+  
+  <para>
+    As you can see using the <classname>WebXmlFinder</classname> is very easy. Just create an instance of the
+    class and then use <methodname>getWebXmlLocation()</methodname> to retrieve the location.
+  </para>
+
+</chapter>


### PR DESCRIPTION
As discussed with Jason I created a class to simplify the use of the WebXmlLocator SPI we migrated from Seam Faces (see SOLDER-265 [1]). The class is called WebXmlFinder and wraps the ServiceLoader lookup and the invocation of the SPI. The class also caches the result of the lookup just like BeanManagerLocator does.

I also added some documentation to the reference guide. Feel free to give any kind of feedback! :)

[1] https://issues.jboss.org/browse/SOLDER-265
