### PR TITLE
SOLDER-126: support primitive typed properties

### DIFF
--- a/api/src/main/java/org/jboss/solder/reflection/Reflections.java
+++ b/api/src/main/java/org/jboss/solder/reflection/Reflections.java
@@ -589,9 +589,9 @@ public class Reflections {
      * @throws ExceptionInInitializerError if the initialization provoked by this
      *                                     method fails.
      */
-    public static <T> T getFieldValue(Field field, Object instance, Class<T> expectedType) {
+	public static <T> T getFieldValue(Field field, Object instance, Class<T> expectedType) {
         try {
-            return expectedType.cast(field.get(instance));
+            return Reflections.cast(field.get(instance));
         } catch (IllegalAccessException e) {
             throw new RuntimeException(buildGetFieldValueErrorMessage(field, instance), e);
         } catch (NullPointerException ex) {

--- a/impl/src/main/java/org/jboss/solder/properties/MethodPropertyImpl.java
+++ b/impl/src/main/java/org/jboss/solder/properties/MethodPropertyImpl.java
@@ -18,14 +18,14 @@
  */
 package org.jboss.solder.properties;
 
+import static org.jboss.solder.reflection.Reflections.invokeMethod;
+
 import java.beans.Introspector;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
 import org.jboss.solder.reflection.Reflections;
-
-import static org.jboss.solder.reflection.Reflections.invokeMethod;
 
 /**
  * A bean property based on the value represented by a getter/setter method pair
@@ -105,11 +105,11 @@ class MethodPropertyImpl<V> implements MethodProperty<V> {
         return getterMethod;
     }
 
-    public V getValue(Object instance) {
+	public V getValue(Object instance) {
         if (getterMethod == null) {
             throw new UnsupportedOperationException("Property " + this.setterMethod.getDeclaringClass() + "." + propertyName + " cannot be read, as there is no getter method.");
         }
-        return getJavaClass().cast(invokeMethod(getterMethod, instance));
+        return Reflections.cast(invokeMethod(getterMethod, instance));
     }
 
     public void setValue(Object instance, V value) {

--- a/impl/src/test/java/org/jboss/solder/test/properties/ClassToIntrospect.java
+++ b/impl/src/test/java/org/jboss/solder/test/properties/ClassToIntrospect.java
@@ -24,6 +24,8 @@ public class ClassToIntrospect {
     private String p;
 
     private URL URL;
+	
+	public long primitiveProperty = 0;
 
     public String getName() {
         return name;
@@ -74,4 +76,10 @@ public class ClassToIntrospect {
     public boolean isValidPrimitiveBoolean() {
         return false;
     }
+
+	
+	public long getPrimitiveProperty()
+	{
+		return 0l;
+	}
 }

--- a/impl/src/test/java/org/jboss/solder/test/properties/PropertyFromFieldTest.java
+++ b/impl/src/test/java/org/jboss/solder/test/properties/PropertyFromFieldTest.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.test.properties;
+
+import java.lang.reflect.Field;
+
+import org.jboss.solder.properties.FieldProperty;
+import org.jboss.solder.properties.Properties;
+import org.junit.Test;
+
+/**
+ * Verify that only valid properties are permitted, as per the JavaBean specification.
+ *
+ * @author Vivian Steller
+ */
+public class PropertyFromFieldTest {
+	
+	@Test
+	public void testAccessingPrimitiveTypedFieldProperty() throws Exception
+	{
+		final Field field = ClassToIntrospect.class.getField("primitiveProperty");
+		
+		FieldProperty<Object> propertyUT = Properties.createProperty(field);
+		propertyUT.getValue(new ClassToIntrospect());
+	}
+	
+}

--- a/impl/src/test/java/org/jboss/solder/test/properties/PropertyFromMethodTest.java
+++ b/impl/src/test/java/org/jboss/solder/test/properties/PropertyFromMethodTest.java
@@ -16,18 +16,17 @@
  */
 package org.jboss.solder.test.properties;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.lang.reflect.Method;
 import java.net.URL;
 
+import org.jboss.solder.properties.MethodProperty;
 import org.jboss.solder.properties.Properties;
 import org.jboss.solder.properties.Property;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Verify that only valid properties are permitted, as per the JavaBean specification.
@@ -117,4 +116,13 @@ public class PropertyFromMethodTest {
 
         assertNotNull(p);
     }
+    
+	@Test
+	public void testAccessingPrimitiveTypedMethodProperty() throws Exception
+	{
+		final Method method = ClassToIntrospect.class.getMethod("getPrimitiveProperty");
+		
+		MethodProperty<Object> propertyUT = Properties.createProperty(method);
+		propertyUT.getValue(new ClassToIntrospect());
+	}
 }


### PR DESCRIPTION
Avoid ClassCastException when casting to primitive value. Without this fix, the Properties functionality is rather useless for framework authors as primitive properties are a quite common requirement.
