### PR TITLE
WebResourceLocator for retrieving web resources without the ServletContext

### DIFF
--- a/api/src/main/java/org/jboss/solder/servlet/resource/WebResourceLocationProvider.java
+++ b/api/src/main/java/org/jboss/solder/servlet/resource/WebResourceLocationProvider.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.servlet.resource;
+
+import java.net.URL;
+
+import javax.servlet.ServletContext;
+
+import org.jboss.solder.util.Sortable;
+
+/**
+ * 
+ * SPI for finding the location of web resources without using {@link ServletContext}.
+ * 
+ * @author Christian Kaltepoth
+ * 
+ */
+public interface WebResourceLocationProvider extends Sortable {
+
+    /**
+     * Returns the location of a web resource. The path must begin with a <tt>/</tt> and is interpreted as relative to the
+     * current context root.
+     * 
+     * @param path The path of the resource to lookup (e.g. "/WEB-INF/web.xml")
+     * @param classLoader The classloader to use for resource lookups
+     * 
+     * @return The location of the resource or <code>null</code> if the location could not be found
+     */
+    URL getWebResource(String path, ClassLoader classLoader);
+
+}

--- a/api/src/main/java/org/jboss/solder/servlet/resource/WebResourceLocator.java
+++ b/api/src/main/java/org/jboss/solder/servlet/resource/WebResourceLocator.java
@@ -1,0 +1,91 @@
+package org.jboss.solder.servlet.resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.servlet.ServletContext;
+
+import org.jboss.solder.logging.Logger;
+import org.jboss.solder.util.Sortable;
+import org.jboss.solder.util.service.ServiceLoader;
+
+/**
+ * <p>
+ * A utility for classes that need to access web resources.
+ * </p>
+ * <p>
+ * This class provides a way to obtain the location of web resources without using the {@link ServletContext}. This is
+ * especially interesting for extensions that are executed very early in the CDI startup process because the
+ * {@link ServletContext} may not be available in this stage.
+ * </p>
+ * <p>
+ * The class makes use of the {@link WebResourceLocationProvider} SPI to actually find the resources. This allows to write
+ * custom implementations optimized for specific environments.
+ * </p>
+ * 
+ * @author Christian Kaltepoth
+ * 
+ * @see WebResourceLocationProvider
+ * 
+ */
+public class WebResourceLocator {
+
+    private final Logger log = Logger.getLogger(WebResourceLocator.class);
+
+    /**
+     * Returns the resource located at the named path as an <code>InputStream</code> object. The path must begin with a
+     * <tt>/</tt> and is interpreted as relative to the current context root.
+     * 
+     * @param path The path of the resource (e.g. "/WEB-INF/web.xml")
+     * @return the <code>InputStream</code> or <code>null</code> if the resource could not be located
+     */
+    public InputStream getWebResource(String path) {
+
+        // build sorted list of provider implementations
+        List<WebResourceLocationProvider> providers = new ArrayList<WebResourceLocationProvider>();
+        Iterator<WebResourceLocationProvider> iterator = ServiceLoader.load(WebResourceLocationProvider.class).iterator();
+        while (iterator.hasNext()) {
+            providers.add(iterator.next());
+        }
+        Collections.sort(providers, new Sortable.Comparator());
+
+        // prefer the context classloader
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = this.getClass().getClassLoader();
+        }
+
+        // process each provider one by one
+        for (WebResourceLocationProvider provider : providers) {
+
+            // execute the SPI implementation
+            URL resourceLocation = provider.getWebResource(path, classLoader);
+
+            // accept the first result
+            if (resourceLocation != null) {
+
+                // try to open an InputStream
+                try {
+                    return resourceLocation.openStream();
+                }
+                // log failure and continue with next provider
+                catch (IOException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Error opening: " + resourceLocation.toString(), e);
+                    }
+                }
+
+            }
+
+        }
+
+        return null;
+
+    }
+
+}

--- a/docs/src/main/docbook/en-US/master.xml
+++ b/docs/src/main/docbook/en-US/master.xml
@@ -65,6 +65,7 @@
     <xi:include href="servlet-injectable_refs.xml"/>
     <xi:include href="servlet-exception_handling.xml"/>
     <xi:include href="servlet-beanmanager.xml"/>
+    <xi:include href="servlet-resource.xml"/>
   </part>
   <toc/>
 </book>

--- a/docs/src/main/docbook/en-US/servlet-resource.xml
+++ b/docs/src/main/docbook/en-US/servlet-resource.xml
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  JBoss, Home of Professional Open Source
+  Copyright 2010, Red Hat Middleware LLC, and individual contributors
+  by the @authors tag. See the copyright.txt in the distribution for a
+  full listing of individual contributors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" []>
+<chapter id="webresources">
+  <title>Loading web resources without ServletContext</title>
+  
+  <para>
+    Sometimes developers need to access web application resources from application code. Typically the 
+    <classname>ServletContext</classname> is used to load resources by calling <methodname>getResource()</methodname>. 
+    Unfortunately the <classname>ServletContext</classname> cannot be accessed in all situations. 
+    Especially CDI extensions can be problematic in this regard as they are executed during a stage in the 
+    application startup in which the <classname>ServletContext</classname> may not have been created yet.
+  </para>
+  
+  <para>
+    Solder offers some help in this situation. The class <classname>WebResourceLocator</classname> provides a simple
+    way to obtain resources from the web application. Under the covers this class uses the 
+    <classname>WebResourceLocationProvider</classname> SPI to retrieve the location of the resources. 
+  </para>
+  
+  <para>
+    The following example shows how to use the class:
+  </para>
+
+  <programlisting role="JAVA"><![CDATA[
+WebResourceLocator locator = new WebResourceLocator();
+
+InputStream stream = locator.getWebResource("/WEB-INF/web.xml");
+
+if (stream != null) {
+
+  // parse the input stream
+
+}
+]]>
+  </programlisting>
+  
+  <para>
+    As you can see using the <classname>WebResourceLocator</classname> is very easy. Just create an instance of the
+    class and then use <methodname>getWebResource()</methodname> to retrieve an InputStream.
+  </para>
+  
+  <warning>
+    <para>
+      Please note that you should always prefer to use the standard Servlet API to load resources from the web
+      application if possible. This Solder API is only intended to be used if it is not possible to use the
+      <classname>ServletContext</classname> (like for example in CDI extensions). 
+    </para>
+  </warning>
+
+</chapter>

--- a/docs/src/main/docbook/en-US/solder-book_info.xml
+++ b/docs/src/main/docbook/en-US/solder-book_info.xml
@@ -36,6 +36,10 @@
       <firstname>Nicklas</firstname>
       <surname>Karlsson</surname>
     </author>
+    <author>
+      <firstname>Christian</firstname>
+      <surname>Kaltepoth</surname>
+    </author>
   </authorgroup>
 <!--
 vim:et:ts=3:sw=3:tw=120

--- a/impl/src/main/java/org/jboss/solder/servlet/resource/DirectoryNameResourceProvider.java
+++ b/impl/src/main/java/org/jboss/solder/servlet/resource/DirectoryNameResourceProvider.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.servlet.resource;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.jboss.solder.logging.Logger;
+
+/**
+ * <p>
+ * This implementation of {@link WebResourceLocationProvider} will try to identify the location of web resources by searching
+ * for a known resource on the classpath and trying to find the <code>WEB-INF</code> directory in its path name. This will
+ * typically work if the known resource in located in a JAR file inside the <code>WEB-INF/lib</code> directory.
+ * </p>
+ * 
+ * <p>
+ * Compared to {@link URLClassLoaderResourceProvider} this implementation works fine even for containers like JBoss AS6 and AS7.
+ * </p>
+ * 
+ * @author Christian Kaltepoth <christian@kaltepoth.de>
+ * 
+ */
+public class DirectoryNameResourceProvider implements WebResourceLocationProvider {
+
+    private final Logger log = Logger.getLogger(DirectoryNameResourceProvider.class);
+
+    @Override
+    public int getPrecedence() {
+        return 50;
+    }
+
+    @Override
+    public URL getWebResource(String path, ClassLoader classLoader) {
+
+        // try to load a resource that MUST exist
+        String relativeResourceName = this.getClass().getName().replace('.', '/') + ".class";
+        URL knownResource = classLoader.getResource(relativeResourceName);
+
+        // we cannot proceed without that resource
+        if (knownResource == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Could not find resource: " + relativeResourceName);
+            }
+            return null;
+        }
+
+        // we will now work on the absolute path of this URL
+        String url = knownResource.toString();
+
+        if (log.isTraceEnabled()) {
+            log.trace("Found known resource: " + url);
+        }
+
+        // is the resource located inside a JAR file? Remove the jar-specific part.
+        if (url.startsWith("jar:") && url.contains("!")) {
+
+            url = url.substring(4, url.lastIndexOf("!"));
+
+            if (log.isTraceEnabled()) {
+                log.trace("Location of JAR file containing the resource: " + url);
+            }
+
+        }
+
+        // should always work as the URL is built using an existing URL
+        try {
+
+            // try to locate the WEB-INF directory
+            int i = url.lastIndexOf("/WEB-INF/lib/");
+            if (i >= 0) {
+                return new URL(url.substring(0, i) + path);
+            }
+
+        } catch (MalformedURLException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to create URL instance!", e);
+            }
+        }
+        return null;
+
+    }
+}

--- a/impl/src/main/java/org/jboss/solder/servlet/resource/URLClassLoaderResourceProvider.java
+++ b/impl/src/main/java/org/jboss/solder/servlet/resource/URLClassLoaderResourceProvider.java
@@ -1,0 +1,118 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.servlet.resource;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.jboss.solder.logging.Logger;
+
+/**
+ * This implementation of {@link WebResourceLocationProvider} will try to identify the location of web resources by examining
+ * the URLs the classloader uses for loading classes. This will only work if the classloader is a {@link URLClassLoader}.
+ * 
+ * @author Christian Kaltepoth <christian@kaltepoth.de>
+ * 
+ */
+public class URLClassLoaderResourceProvider implements WebResourceLocationProvider {
+
+    private final Logger log = Logger.getLogger(URLClassLoaderResourceProvider.class);
+
+    @Override
+    public int getPrecedence() {
+        return 100;
+    }
+
+    @Override
+    public URL getWebResource(String path, ClassLoader classLoader) {
+
+        // this class only works for URLClassLoaders
+        if (classLoader instanceof URLClassLoader) {
+
+            URLClassLoader urlClassLoader = (URLClassLoader) classLoader;
+
+            // get the URLs of the classloader
+            for (URL classLoaderUrl : urlClassLoader.getURLs()) {
+
+                // try this URL to locate the web resource
+                URL possibleWebResourceLocation = processClassLoaderSearchPath(classLoaderUrl, path);
+
+                // we will use the first result we get
+                if (possibleWebResourceLocation != null) {
+                    return possibleWebResourceLocation;
+                }
+
+            }
+
+        }
+
+        // log class loader type in all other cases
+        else {
+            if (log.isTraceEnabled()) {
+                log.trace("Context class loader is not an URLClassLoader but: "
+                        + (classLoader != null ? classLoader.getClass().getName() : "null"));
+            }
+        }
+
+        return null;
+
+    }
+
+    /**
+     * Try to locate the web resource using the supplied classloader URL.
+     * 
+     * @param classPathUrl The {@link URL} the classloader uses to look for classes
+     * @param path The path to lookup (e.g. "/WEB-INF/web.xml")
+     * @return The guessed location of the web resource or <code>null</code> if it could not be determined
+     */
+    private URL processClassLoaderSearchPath(URL classPathUrl, String path) {
+
+        // we use string comparisons here
+        String location = classPathUrl.toString();
+
+        // ignore JAR files as they don't help us
+        if (location.endsWith(".jar")) {
+            return null;
+        }
+
+        if (log.isTraceEnabled()) {
+            log.trace("Found URL of directory: " + location);
+        }
+
+        // should always work as the URL is built using an existing URL
+        try {
+
+            // Works for most containers like Tomcat, Jetty and Glassfish
+            if (location.endsWith("/WEB-INF/classes/")) {
+                return new URL(location.substring(0, location.length() - 17) + path);
+            }
+
+            // special hack for the Maven Jetty plugin
+            if (location.endsWith("/target/classes/")) {
+                return new URL(location.substring(0, location.length() - 16) + "/src/main/webapp" + path);
+            }
+
+        } catch (MalformedURLException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to create URL instance!", e);
+            }
+        }
+        return null;
+
+    }
+}

--- a/impl/src/main/resources/META-INF/services/org.jboss.solder.servlet.resource.WebResourceLocationProvider
+++ b/impl/src/main/resources/META-INF/services/org.jboss.solder.servlet.resource.WebResourceLocationProvider
@@ -1,0 +1,2 @@
+org.jboss.solder.servlet.resource.DirectoryNameResourceProvider
+org.jboss.solder.servlet.resource.URLClassLoaderResourceProvider

--- a/impl/src/test/java/org/jboss/solder/test/servlet/resource/DirectoryNameResourceProviderTest.java
+++ b/impl/src/test/java/org/jboss/solder/test/servlet/resource/DirectoryNameResourceProviderTest.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.test.servlet.resource;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+
+import java.net.URL;
+
+import org.jboss.solder.servlet.resource.DirectoryNameResourceProvider;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit test for {@link DirectoryNameResourceProvider}. Please note that this test won't use the 'vfs' protocol because
+ * this won't work in a simple unit test outside of a container. We will simply use the 'file' protocol instead, which
+ * will also work fine to verify the results.
+ *
+ * @author Christian Kaltepoth <christian@kaltepoth.de>
+ *
+ */
+public class DirectoryNameResourceProviderTest {
+
+    @Test
+    public void testResourceFromWebLibDirectoryAS7() throws Exception {
+
+        final String resourceName = DirectoryNameResourceProvider.class.getName().replace('.', '/') + ".class";
+        final URL resourceUrl = new URL("file:/jboss-home/server/default/deploy/seam-faces-tests.war/WEB-INF/lib/seam-faces-3.1.0-SNAPSHOT.jar/" + resourceName);
+
+        ClassLoader classLoader = Mockito.mock(ClassLoader.class);
+        Mockito.when(classLoader.getResource(resourceName)).thenReturn(resourceUrl);
+
+        DirectoryNameResourceProvider locator = new DirectoryNameResourceProvider();
+        URL resultUrl = locator.getWebResource("/WEB-INF/beans.xml", classLoader);
+
+        assertNotNull(resultUrl);
+        assertEquals("file:/jboss-home/server/default/deploy/seam-faces-tests.war/WEB-INF/beans.xml", resultUrl.toString());
+
+    }
+
+    @Test
+    public void testResourceFromWebLibDirectoryAS6() throws Exception {
+
+        final String resourceName = DirectoryNameResourceProvider.class.getName().replace('.', '/') + ".class";
+        final URL resourceUrl = new URL("file:/content/seam-faces-tests.war/WEB-INF/lib/seam-faces-3.1.0-SNAPSHOT.jar/" + resourceName);
+
+        ClassLoader classLoader = Mockito.mock(ClassLoader.class);
+        Mockito.when(classLoader.getResource(resourceName)).thenReturn(resourceUrl);
+
+        DirectoryNameResourceProvider locator = new DirectoryNameResourceProvider();
+        URL resultUrl = locator.getWebResource("/WEB-INF/beans.xml", classLoader);
+
+        assertNotNull(resultUrl);
+        assertEquals("file:/content/seam-faces-tests.war/WEB-INF/beans.xml", resultUrl.toString());
+
+    }
+
+    @Test
+    public void testResourceFromWebLibDirectoryTomcat7() throws Exception {
+
+        final String resourceName = DirectoryNameResourceProvider.class.getName().replace('.', '/') + ".class";
+        final URL resourceUrl = new URL("jar:file:/tomcat-home/webapps/seam-faces-tests/WEB-INF/lib/seam-faces-3.1.0-SNAPSHOT.jar!/" + resourceName);
+
+        ClassLoader classLoader = Mockito.mock(ClassLoader.class);
+        Mockito.when(classLoader.getResource(resourceName)).thenReturn(resourceUrl);
+
+        DirectoryNameResourceProvider locator = new DirectoryNameResourceProvider();
+        URL resultUrl = locator.getWebResource("/WEB-INF/beans.xml", classLoader);
+
+        assertNotNull(resultUrl);
+        assertEquals("file:/tomcat-home/webapps/seam-faces-tests/WEB-INF/beans.xml", resultUrl.toString());
+
+    }
+
+}

--- a/impl/src/test/java/org/jboss/solder/test/servlet/resource/URLClassLoaderResourceProviderTest.java
+++ b/impl/src/test/java/org/jboss/solder/test/servlet/resource/URLClassLoaderResourceProviderTest.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.test.servlet.resource;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.jboss.solder.servlet.resource.URLClassLoaderResourceProvider;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class URLClassLoaderResourceProviderTest {
+
+    @Test
+    public void testNotAnUrlClassLoader() {
+
+        ClassLoader classLoader = Mockito.mock(ClassLoader.class);
+
+        URL result = new URLClassLoaderResourceProvider().getWebResource("/WEB-INF/beans.xml", classLoader);
+
+        assertNull(result);
+
+    }
+
+    @Test
+    public void testUrlClassLoaderWithoutUrls() {
+
+        URLClassLoader classLoader = Mockito.mock(URLClassLoader.class);
+        Mockito.when(classLoader.getURLs()).thenReturn(new URL[0]);
+
+        URL result = new URLClassLoaderResourceProvider().getWebResource("/WEB-INF/beans.xml", classLoader);
+
+        assertNull(result);
+
+    }
+
+    @Test
+    public void testUrlClassLoaderWithoutHelpfulUrls() throws MalformedURLException {
+
+        URLClassLoader classLoader = Mockito.mock(URLClassLoader.class);
+        Mockito.when(classLoader.getURLs()).thenReturn(new URL[] { new URL("file:/tmp/test.jar") });
+
+        URL result = new URLClassLoaderResourceProvider().getWebResource("/WEB-INF/beans.xml", classLoader);
+
+        assertNull(result);
+
+    }
+
+    @Test
+    public void testUrlClassLoaderWithClassesDirectory() throws MalformedURLException {
+
+        URLClassLoader classLoader = Mockito.mock(URLClassLoader.class);
+        Mockito.when(classLoader.getURLs()).thenReturn(new URL[] {
+                new URL("file:/tmp/myapp/WEB-INF/lib/test.jar"),
+                new URL("file:/tmp/myapp/WEB-INF/classes/"),
+                new URL("file:/tmp/myapp/WEB-INF/lib/test2.jar")
+        });
+
+        URL result = new URLClassLoaderResourceProvider().getWebResource("/WEB-INF/beans.xml", classLoader);
+
+        assertNotNull(result);
+        assertEquals("file:/tmp/myapp/WEB-INF/beans.xml", result.toString());
+
+    }
+
+    @Test
+    public void testUrlClassLoaderWithMavenJettyPlugin() throws MalformedURLException {
+
+        URLClassLoader classLoader = Mockito.mock(URLClassLoader.class);
+        Mockito.when(classLoader.getURLs()).thenReturn(new URL[] {
+                new URL("file:/home/user/.m2/repository/group/artifact/1.0/artifact-1.0.jar"),
+                new URL("file:/somewhere/myapp/target/classes/"),
+                new URL("file:/home/user/.m2/repository/group/artifact2/1.0/artifact2-1.0.jar"),
+        });
+
+        URL result = new URLClassLoaderResourceProvider().getWebResource("/WEB-INF/beans.xml", classLoader);
+
+        assertNotNull(result);
+        assertEquals("file:/somewhere/myapp/src/main/webapp/WEB-INF/beans.xml", result.toString());
+
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/servlet/test/jbossas/resource/WebResourceLocatorTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/servlet/test/jbossas/resource/WebResourceLocatorTest.java
@@ -1,0 +1,104 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.solder.servlet.test.jbossas.resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.solder.servlet.resource.WebResourceLocator;
+import org.jboss.solder.servlet.test.weld.util.Deployments;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * 
+ * Integration test for {@link WebResourceLocator}
+ * 
+ * @author Christian Kaltepoth
+ * 
+ */
+@RunWith(Arquillian.class)
+public class WebResourceLocatorTest {
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return Deployments.createMockableBeanWebArchive()
+                .addClasses(WebResourceLocatorTest.class)
+                .addAsWebResource(new StringAsset("Some web resource"), "web-resource.txt")
+                .addAsWebInfResource(new StringAsset("Some file in WEB-INF directory"), "web-inf-file.txt");
+    }
+
+    @Test
+    public void loadSomeWebResource() {
+
+        WebResourceLocator locator = new WebResourceLocator();
+        InputStream stream = locator.getWebResource("/web-resource.txt");
+
+        assertNotNull("WebResourceLocator did not find the resource", stream);
+
+        String text = readFirstLine(stream);
+        assertEquals("Some web resource", text);
+
+    }
+
+    @Test
+    public void loadResourceFromWebInfDirectory() {
+
+        WebResourceLocator locator = new WebResourceLocator();
+        InputStream stream = locator.getWebResource("/WEB-INF/web-inf-file.txt");
+
+        assertNotNull("WebResourceLocator did not find the resource", stream);
+
+        String text = readFirstLine(stream);
+        assertEquals("Some file in WEB-INF directory", text);
+
+    }
+
+    private String readFirstLine(InputStream stream) {
+
+        BufferedReader reader = null;
+        try {
+
+            reader = new BufferedReader(new InputStreamReader(stream, Charset.forName("UTF-8")));
+            return reader.readLine();
+
+        } catch (IOException e) {
+
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException ignore) {
+                    // ignore
+                }
+            }
+        }
+
+        return null;
+
+    }
+
+}

--- a/testsuite/src/test/java/org/jboss/solder/servlet/test/jbossas/resource/WebResourceLocatorTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/servlet/test/jbossas/resource/WebResourceLocatorTest.java
@@ -18,6 +18,7 @@ package org.jboss.solder.servlet.test.jbossas.resource;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -75,6 +76,16 @@ public class WebResourceLocatorTest {
 
         String text = readFirstLine(stream);
         assertEquals("Some file in WEB-INF directory", text);
+
+    }
+
+    @Test
+    public void loadResourceThatDoesNotExist() {
+
+        WebResourceLocator locator = new WebResourceLocator();
+        InputStream stream = locator.getWebResource("/does-not-exist.txt");
+
+        assertNull(stream);
 
     }
 


### PR DESCRIPTION
As discussed with Jason I refactored the WebXmlLocator SPI to provide a more general interface for reading arbitrary resources from a web application without the ServletContext. 

This pull request includes:
- WebResourceLocationProvider SPI including two implementations and a unit test for each
- WebResourceLocator which wraps the ServiceLoader lookup and the invocation of the SPI implementations
- An Arquillian test for AS7
- A small chapter for the reference documentation

Feel free to give any kind of feedback! :)
