### PR TITLE
SOLDER-153 handledException in conversation scope

### DIFF
--- a/impl/src/main/java/org/jboss/solder/exception/control/ExceptionHandlerDispatch.java
+++ b/impl/src/main/java/org/jboss/solder/exception/control/ExceptionHandlerDispatch.java
@@ -39,7 +39,8 @@ import org.jboss.solder.logging.Logger;
  * Observer of {@link ExceptionToCatch} events and handler dispatcher. All handlers are invoked from this class.  This
  * class is immutable.
  */
-public class ExceptionHandlerDispatch {
+@ConversationScoped
+public class ExceptionHandlerDispatch implements java.io.Serializable {
     private ExceptionToCatch exceptionToCatch;
     private ExceptionStack exceptionStack;
 

--- a/impl/src/main/java/org/jboss/solder/exception/control/ExceptionHandlerDispatch.java
+++ b/impl/src/main/java/org/jboss/solder/exception/control/ExceptionHandlerDispatch.java
@@ -39,7 +39,6 @@ import org.jboss.solder.logging.Logger;
  * Observer of {@link ExceptionToCatch} events and handler dispatcher. All handlers are invoked from this class.  This
  * class is immutable.
  */
-@ConversationScoped
 public class ExceptionHandlerDispatch implements java.io.Serializable {
     private ExceptionToCatch exceptionToCatch;
     private ExceptionStack exceptionStack;

--- a/impl/src/main/java/org/jboss/solder/exception/control/ExceptionHandlerDispatch.java
+++ b/impl/src/main/java/org/jboss/solder/exception/control/ExceptionHandlerDispatch.java
@@ -186,13 +186,13 @@ public class ExceptionHandlerDispatch implements java.io.Serializable {
     @ConversationScoped
     @Named("handledException")
     public ExceptionStack getExceptionStack() {
-        return this.exceptionStack;
+        return this.exceptionStack == null ? new ExceptionStack() : this.exceptionStack;
     }
 
     @Produces
     @ConversationScoped
     @Named("caughtException")
     public ExceptionToCatch getExceptionToCatch() {
-        return this.exceptionToCatch;
+        return this.exceptionToCatch == null ? new ExceptionToCatch() : this.exceptionToCatch;
     }
 }


### PR DESCRIPTION
ExceptionHandlerDispatch is invalid, cause it's in dependant scope so when it sets exceptionToCatch or exceptionStack it's different instance then when @Produces method for handledException is called which always results in null.
