### PR TITLE
NPE from ExceptionStack initialized with default constructor.

### DIFF
--- a/api/src/main/java/org/jboss/solder/exception/control/ExceptionStack.java
+++ b/api/src/main/java/org/jboss/solder/exception/control/ExceptionStack.java
@@ -138,7 +138,7 @@ public class ExceptionStack implements Serializable {
     }
 
     public Collection<Throwable> getCauseElements() {
-        return Collections.unmodifiableCollection(this.causes);
+        return this.causes == null ? Collections.<Throwable>emptyList() : Collections.unmodifiableCollection(this.causes);
     }
 
     /**
@@ -155,7 +155,8 @@ public class ExceptionStack implements Serializable {
     }
 
     public Collection<Throwable> getRemaining() {
-        return Collections.unmodifiableCollection(this.createThrowableCollectionFrom(this.remaining));
+        return this.remaining == null ? Collections.<Throwable>emptyList() : Collections.unmodifiableCollection(
+            this.createThrowableCollectionFrom(this.remaining));
     }
 
     /**


### PR DESCRIPTION
Right now when page wants to access ExceptionStack via EL "handledException" and there was no exception yet, then uninitialized object is returned and if we all i.e. getCauseElements() we get NPE. This pull fixes it.
