### PR TITLE
SOLDER-336 fix; enable jbossas-remote-7 profile

### DIFF
--- a/impl/src/main/java/org/jboss/solder/bean/generic/AbstractGenericProducerBean.java
+++ b/impl/src/main/java/org/jboss/solder/bean/generic/AbstractGenericProducerBean.java
@@ -72,7 +72,7 @@ abstract class AbstractGenericProducerBean<T> extends AbstractGenericBean<T> {
 
     protected Object getReceiver(CreationalContext<T> creationalContext) {
         Bean<?> declaringBean = getDeclaringBean();
-        return getBeanManager().getReference(declaringBean, declaringBean.getBeanClass(), creationalContext);
+        return getBeanManager().getReference(declaringBean, getDeclaringBeanType(), creationalContext);
     }
 
     protected Bean<?> getDeclaringBean() {

--- a/impl/src/main/java/org/jboss/solder/bean/generic/GenericBeanExtension.java
+++ b/impl/src/main/java/org/jboss/solder/bean/generic/GenericBeanExtension.java
@@ -375,6 +375,11 @@ public class GenericBeanExtension implements Extension {
     }
 
     <T, X> void registerGenericBeanObserverMethod(@Observes ProcessObserverMethod<T, X> event) {
+    	
+    	if (event.getAnnotatedMethod() == null) {
+    		return;
+    	}
+    	
         AnnotatedType<X> declaringType = event.getAnnotatedMethod().getDeclaringType();
         if (declaringType.isAnnotationPresent(GenericConfiguration.class)) {
             AnnotatedMethod<X> method = event.getAnnotatedMethod();

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
    <parent>
       <groupId>org.jboss.seam</groupId>
       <artifactId>seam-parent</artifactId>
-      <version>19</version>
+      <version>20-SNAPSHOT</version>
    </parent>
 
    <groupId>org.jboss.solder</groupId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -172,6 +172,46 @@
         </profile> 
 
         <profile>
+            <id>jbossas-remote-7</id>
+            <activation>
+                <property>
+                    <name>arquillian</name>
+                    <value>jbossas-remote-7</value>
+                </property>
+            </activation>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.seam.test</groupId>
+                    <artifactId>jbossas-remote-7</artifactId>
+                    <type>pom</type>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.protocol</groupId>
+                    <artifactId>arquillian-protocol-servlet</artifactId>
+                    <version>${arquillian.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+
+            <build>
+               <plugins>
+                  <plugin>
+                     <groupId>org.apache.maven.plugins</groupId>
+                     <artifactId>maven-surefire-plugin</artifactId>
+                     <configuration>
+                        <excludes>
+                           <exclude>**/weld/**</exclude>
+                        </excludes>
+                     </configuration>
+                  </plugin>
+               </plugins>
+            </build>
+        </profile> 
+
+
+        <profile>
             <id>glassfish-embedded-3.1</id>
             <activation>
                 <property>

--- a/testsuite/src/test/java/org/jboss/solder/test/bean/generic/method/GenericProductTest.java
+++ b/testsuite/src/test/java/org/jboss/solder/test/bean/generic/method/GenericProductTest.java
@@ -112,7 +112,7 @@ public class GenericProductTest {
 
         bean = manager.resolve(manager.getBeans(HashMap.class, new FooLiteral(1)));
         ctx = manager.createCreationalContext(bean);
-        manager.getReference(bean, String.class, ctx);
+        manager.getReference(bean, HashMap.class, ctx);
         ctx.release();
         Assert.assertTrue(Garply.isMapDisposerCalled());
     }

--- a/testsuite/src/test/resources/arquillian.xml
+++ b/testsuite/src/test/resources/arquillian.xml
@@ -32,6 +32,9 @@
        </configuration>
     </container>
 
+    <container qualifier="jbossas-remote-7">
+    </container>
+
     <container qualifier="glassfish-embedded-3.1">
       <configuration>
         <property name="bindHttpPort">7171</property>


### PR DESCRIPTION
Solder generic beans depend on buggy Weld behaviour and have incorrect assumptions:
1. ProcessObserverMethod::getAnnotatedMethod() is never null
2. BeanManager::getReference doesn't check types

This patch fixes these and makes solder work on Weld 1.1.x again
