### PR TITLE
Fixed access modifiers for inner classes to avoid classloading issues

### DIFF
--- a/impl/src/main/java/org/jboss/solder/servlet/event/ImplicitServletObjectsHolder.java
+++ b/impl/src/main/java/org/jboss/solder/servlet/event/ImplicitServletObjectsHolder.java
@@ -161,9 +161,8 @@ public class ImplicitServletObjectsHolder {
         }
     }
 
-    /**
-     * Fixed access modifier for class and contructor to <code>public</code> in order to avoid class loading issues with EAP static modules (java.lang.IllegalAccessError)
-     */
+     // Fixed access modifier for class and contructor to <code>public</code> in order to avoid class loading
+     // issues with EAP static modules (java.lang.IllegalAccessError)
     public static class InternalServletContextEvent {
         private ServletContext ctx;
 
@@ -176,9 +175,8 @@ public class ImplicitServletObjectsHolder {
         }
     }
 
-    /**
-     * Fixed access modifier for class and contructor to <code>public</code> in order to avoid class loading issues with EAP static modules (java.lang.IllegalAccessError)
-     */
+    // Fixed access modifier for class and contructor to <code>public</code> in order to avoid class loading
+    // issues with EAP static modules (java.lang.IllegalAccessError)
     public static class InternalServletRequestEvent {
         private ServletRequest request;
 
@@ -191,9 +189,8 @@ public class ImplicitServletObjectsHolder {
         }
     }
 
-    /**
-     * Fixed access modifier for class and contructor to <code>public</code> in order to avoid class loading issues with EAP static modules (java.lang.IllegalAccessError)
-     */
+    // Fixed access modifier for class and contructor to <code>public</code> in order to avoid class loading
+    // issues with EAP static modules (java.lang.IllegalAccessError)
     public static class InternalServletResponseEvent {
         private ServletResponse response;
 
@@ -206,9 +203,8 @@ public class ImplicitServletObjectsHolder {
         }
     }
 
-    /**
-     * Fixed access modifier for class and contructor to <code>public</code> in order to avoid class loading issues with EAP static modules (java.lang.IllegalAccessError)
-     */
+    // Fixed access modifier for class and contructor to <code>public</code> in order to avoid class loading
+    // issues with EAP static modules (java.lang.IllegalAccessError)
     public static class InternalHttpSessionEvent {
         private HttpSession session;
 

--- a/impl/src/main/java/org/jboss/solder/servlet/event/ImplicitServletObjectsHolder.java
+++ b/impl/src/main/java/org/jboss/solder/servlet/event/ImplicitServletObjectsHolder.java
@@ -161,10 +161,13 @@ public class ImplicitServletObjectsHolder {
         }
     }
 
-    static class InternalServletContextEvent {
+    /**
+     * Fixed access modifier for class and contructor to <code>public</code> in order to avoid class loading issues with EAP static modules (java.lang.IllegalAccessError)
+     */
+    public static class InternalServletContextEvent {
         private ServletContext ctx;
 
-        InternalServletContextEvent(ServletContext ctx) {
+        public InternalServletContextEvent(ServletContext ctx) {
             this.ctx = ctx;
         }
 
@@ -173,10 +176,13 @@ public class ImplicitServletObjectsHolder {
         }
     }
 
-    static class InternalServletRequestEvent {
+    /**
+     * Fixed access modifier for class and contructor to <code>public</code> in order to avoid class loading issues with EAP static modules (java.lang.IllegalAccessError)
+     */
+    public static class InternalServletRequestEvent {
         private ServletRequest request;
 
-        InternalServletRequestEvent(ServletRequest request) {
+        public InternalServletRequestEvent(ServletRequest request) {
             this.request = request;
         }
 
@@ -185,10 +191,13 @@ public class ImplicitServletObjectsHolder {
         }
     }
 
-    static class InternalServletResponseEvent {
+    /**
+     * Fixed access modifier for class and contructor to <code>public</code> in order to avoid class loading issues with EAP static modules (java.lang.IllegalAccessError)
+     */
+    public static class InternalServletResponseEvent {
         private ServletResponse response;
 
-        InternalServletResponseEvent(ServletResponse response) {
+        public InternalServletResponseEvent(ServletResponse response) {
             this.response = response;
         }
 
@@ -197,10 +206,13 @@ public class ImplicitServletObjectsHolder {
         }
     }
 
-    static class InternalHttpSessionEvent {
+    /**
+     * Fixed access modifier for class and contructor to <code>public</code> in order to avoid class loading issues with EAP static modules (java.lang.IllegalAccessError)
+     */
+    public static class InternalHttpSessionEvent {
         private HttpSession session;
 
-        InternalHttpSessionEvent(HttpSession session) {
+        public InternalHttpSessionEvent(HttpSession session) {
             this.session = session;
         }
 


### PR DESCRIPTION
As discussed with Pete, package protected access modifiers are causing class loading issues.
